### PR TITLE
Move environemnt logic from config.pp to params.pp

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,18 +49,14 @@ class r10k::config (
   $r10k_basedir,
   $modulepath,
   $manage_modulepath,
-) {
+  $puppetconf_path = $r10k::params::puppetconf_path,
+) inherits r10k::params {
   file { 'r10k.yaml':
     ensure  => file,
     owner   => 'root',
     group   => 'root',
     path    => $configfile,
     content => template("${module_name}/${configfile}.erb"),
-  }
-
-  $puppetconf_path = $::is_pe ? {
-    'true'  => '/etc/puppetlabs/puppet',
-    default => '/etc/puppet',
   }
 
   if $manage_modulepath {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,8 +16,10 @@ class r10k::params
   $remote              = "ssh://${git_server}${repo_path}/modules.git"
   $source_name         = 'jiminy'
 
-  # Puppet Enterprise specific settings
   if $::is_pe == 'true' {
+    # Puppet Enterprise specific settings
+    $puppetconf_path     = '/etc/puppetlabs/puppet'
+
     # Mcollective configuration dynamic
     $mc_service_name     = 'pe-mcollective'
     $plugins_dir         = '/opt/puppet/libexec/mcollective/mcollective'
@@ -25,6 +27,7 @@ class r10k::params
     $pe_ruby             = true
   } else {
     # Getting ready for FOSS support in this module
+    $puppetconf_path     = '/etc/puppet'
 
     # Mcollective configuration dynamic
     $mc_service_name     = 'mcollective'


### PR DESCRIPTION
Environment logic to set parameters can (and should) be located in the params.pp file, rather than spread throughout the codebase. Especially if in params.pp we are already performing a given conditional to set other variables.
