### PR TITLE
Set prerun_command with inifile instead of augeas

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,9 @@ class r10k::params
   $repo_path           = '/var/repos'
   $remote              = "ssh://${git_server}${repo_path}/modules.git"
 
+  # prerun_command in puppet.conf
+  $prerun_command = 'r10k deploy environment -p'
+
   # Bundle to get bleeding edge instead of gem
   $use_bundle          = false
 

--- a/manifests/prerun_command.pp
+++ b/manifests/prerun_command.pp
@@ -1,9 +1,16 @@
 # This class will configure r10k to run as part of the masters agent run
 class r10k::prerun_command (
-  $command = 'r10k synchronize'
-){
-  augeas{'puppet.conf prerun_command' :
-    context       => '/files//puppet.conf/agent',
-    changes       => "set prerun_command 'r10k synchronize'",
+  $command = $r10k::params::prerun_command
+) inherits r10k::params {
+
+  Ini_setting {
+    path    => "$puppetconf_path/puppet.conf",
+    ensure  => present,
+    section => 'agent',
+  }
+
+  ini_setting { 'r10k_prerun_command':
+    setting => 'prerun_command',
+    value   => $command,
   }
 }


### PR DESCRIPTION
This also fixes the deprecation warning of `r10k synchronize`
puppetlabs/inifile is already listed as dependency in the Modulefile (although it doesn't seem to be used anywhere so far)
