### PR TITLE
refresh mco if we install the r10k app

### DIFF
--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -30,6 +30,6 @@ class r10k::mcollective(
   }
 
   Service <| title == $mc_service |> {
-    subscribe => File["${app_path}/${app_name}"],
+    subscribe +> File["${app_path}/${app_name}"],
   }
 }


### PR DESCRIPTION
Move to collector so we are not parse order dependent / conflicting with the mco module for Service[pe-mcollective].
