### PR TITLE
require git only when installing via gem or bundler

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,6 @@ class r10k::install (
   $provider,
   $keywords,
 ) {
-  require git
 
   # There are currently bugs in r10k 1.x which make using 0.x desireable in
   # certain circumstances. However, 0.x requires make and gcc. Conditionally

--- a/manifests/install/gem.pp
+++ b/manifests/install/gem.pp
@@ -3,6 +3,8 @@ class r10k::install::gem (
   $version,
 ) {
 
+  require git
+
   # Ideally we would be singleton here but due to the bug we need the param.
   # If we are newer then the failure state, we do the right thing with include
   if versioncmp($::puppetversion,'3.2.2') < 0 {

--- a/manifests/install/pe_gem.pp
+++ b/manifests/install/pe_gem.pp
@@ -1,4 +1,7 @@
 class r10k::install::pe_gem {
+
+  require git
+
   file { '/usr/bin/r10k':
     ensure => link,
     target => '/opt/puppet/bin/r10k',

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -115,7 +115,7 @@ describe 'r10k::install' , :type => 'class' do
         :operatingsystemrelease => '2.1',
       }
     end
-    it { should include_class("git") }
+    it { should_not include_class("git") }
     it { should contain_class("r10k::install::portage").with(
         :keywords => ['~amd64', '~x86'],
         :version  => '1.1.0'


### PR DESCRIPTION
After talking with @adrienthebo, distro packages of r10k should have git as a 
runtime dependency. If they don't, they are broken and should be fixed
