### PR TITLE
fixes for open-source puppet edition

### DIFF
--- a/manifests/install/gem.pp
+++ b/manifests/install/gem.pp
@@ -7,7 +7,7 @@ class r10k::install::gem (
 
   # Ideally we would be singleton here but due to the bug we need the param.
   # If we are newer then the failure state, we do the right thing with include
-  if versioncmp($::puppetversion,'3.2.2') < 0 {
+  if versioncmp($::puppetversion,'3.2.2') < 0 or $::is_pe == 'false' {
     # https://projects.puppetlabs.com/issues/19663
     class { '::ruby':
       rubygems_update => false,


### PR DESCRIPTION
Hi,

I've tried you modules on CentOS 6.5 with puppet open source and this fix was required in order get this working.
I've tested with puppet 3.2.4 and 3.4.2.

Best regards,
  Attila
