### PR TITLE
Add missing 'sources' attribute ro r10k::params class

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class r10k::params
   $version           = '1.1.0'
   $manage_modulepath = false
   $install_options   = ''
+  $sources           = ''
 
   # r10k configuration
   $r10k_config_file = '/etc/r10k.yaml'


### PR DESCRIPTION
Class r10k references $r10k::params::sources as a default value, but this attribute is missing in r10k::params class.
