### PR TITLE
never update gem with rubygems-update

### DIFF
--- a/manifests/install/gem.pp
+++ b/manifests/install/gem.pp
@@ -5,15 +5,8 @@ class r10k::install::gem (
 
   require git
 
-  # Ideally we would be singleton here but due to the bug we need the param.
-  # If we are newer then the failure state, we do the right thing with include
-  if versioncmp($::puppetversion,'3.2.2') < 0 {
-    # https://projects.puppetlabs.com/issues/19663
-    class { '::ruby':
-      rubygems_update => false,
-    }
-  } else {
-    include ruby
+  class { '::ruby':
+    rubygems_update => false,
   }
 
   include ruby::dev

--- a/spec/classes/install/gem_spec.rb
+++ b/spec/classes/install/gem_spec.rb
@@ -36,7 +36,7 @@ describe 'r10k::install::gem' , :type => 'class' do
       }
     end
     it { should contain_class("ruby").with(
-      'rubygems_update' => true
+      'rubygems_update' => false
       )
     }
     it { should contain_class("ruby::dev") }


### PR DESCRIPTION
Updating gem can have various unforseen side effects. On RHEL 6.x the update changes the default gem path which renders all gems previously installed unavailable without special configuration.

Issue #37
