### PR TITLE
ensure webhook initscript is ordered correctly

### DIFF
--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -15,6 +15,7 @@ class r10k::webhook(
     content => template("${module_name}/etc/init.d/webhook.erb"),
     path    => '/etc/init.d/webhook',
     require => Package['sinatra'],
+    before  => File['webhook_bin'],
   }
   file { 'webhook_bin':
     content => template("${module_name}/usr/local/bin/webhook.erb"),


### PR DESCRIPTION
on the first run, puppet often fails to create the init script until after the service is restarted, e.g.:

```
Notice: /Package[r10k]/ensure: created
Notice: /Stage[main]/R10k::Webhook/File[webhook_bin]/ensure: defined content as '{md5}eff3d99da2a463792685bd8240acc3f3'
Error: Could not start Service[webhook]: Execution of '/sbin/service webhook start' returned 1:
Error: /Stage[main]/R10k::Webhook/Service[webhook]/ensure: change from stopped to running failed: Could not start Service[webhook]: Execution of '/sbin/service webhook start' returned 1:
Notice: /Stage[main]/R10k::Webhook/Service[webhook]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/R10k::Webhook/Package[sinatra]/ensure: created
Notice: /Stage[main]/R10k::Webhook/File[webhook_init_script]/ensure: defined content as '{md5}8b893ead309b6c0fe2d6e2d52f88e907'
```
