### PR TITLE
Stop quoting all configuration options so that prefix is not always on

### DIFF
--- a/templates/r10k.yaml.erb
+++ b/templates/r10k.yaml.erb
@@ -4,7 +4,7 @@
 <% @source_keys.sort.each do |source| -%>
   <%=source-%>:
 <% @r10k_sources[source].sort.each do |key,value| -%>
-    <%=key-%>: "<%=value%>"
+    <%=key-%>: <%=value%>
 <% end -%>
 <% end -%>
 <% end %>


### PR DESCRIPTION
Without this patch, prefix could be set to "false" which is not a
boolean and gets interpreted as true. This could result in your branches
being prefixed with 'puppet_'.
