### PR TITLE
chomp makes the baby ruby cry

### DIFF
--- a/files/webhook
+++ b/files/webhook
@@ -128,7 +128,7 @@ class Server  < Sinatra::Base
       IO.popen($config['prefix_command'], mode='r+') do |io|
           io.write payload.to_s
           io.close_write
-          result = io.readlines.first.chomp
+          result = io.readlines.first.to_s
       end
     end #end run_prefix_command
 


### PR DESCRIPTION
chomp was causing an error during my test:

curl -d '{ "ref": "refs/heads/production" }'  -H "Accept: application/json" 'http://puppet:puppet@<master>:8088/payload' -k -q
NoMethodError: undefined method `chomp' for nil:NilClass

changing 'chomp' to 'to_s' corrected the problem and resulted in a successful test:

curl -d '{ "ref": "refs/heads/production" }'  -H "Accept: application/json" 'http://puppet:puppet@<master>:8088/payload' -k -q
{"status":"success","message":"triggered: mco r10k deploy _production -p"}
