### PR TITLE
Fix default postrun_command

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class r10k::params
   $remote     = "ssh://${git_server}${repo_path}/modules.git"
 
   # prerun_command in puppet.conf
-  $prerun_command = 'r10k deploy environment -p'
+  $pre_postrun_command = 'r10k deploy environment -p'
 
   # Gentoo specific values
   $gentoo_keywords = ''

--- a/manifests/postrun_command.pp
+++ b/manifests/postrun_command.pp
@@ -1,6 +1,6 @@
 # This class will configure r10k to run as part of the masters agent run
 class r10k::postrun_command (
-  $command = $r10k::params::postrun_command,
+  $command = $r10k::params::pre_postrun_command,
   $ensure  = 'present',
 ) inherits r10k::params {
 

--- a/manifests/prerun_command.pp
+++ b/manifests/prerun_command.pp
@@ -1,6 +1,6 @@
 # This class will configure r10k to run as part of the masters agent run
 class r10k::prerun_command (
-  $command = $r10k::params::prerun_command,
+  $command = $r10k::params::pre_postrun_command,
   $ensure  = 'present',
 ) inherits r10k::params {
 


### PR DESCRIPTION
The r10k::postrun_command command parameter was pointing to a
non-existent variable in params.  This commit resolves this by setting a
"pre_postrun_command" in params.pp that both the prerun_command and
postrun_command classes use as default values for their 'command'
parameters.
