### PR TITLE
change webhook exec to execute the command built previously

### DIFF
--- a/files/webhook
+++ b/files/webhook
@@ -102,7 +102,7 @@ class Server  < Sinatra::Base
             command = "/opt/puppet/bin/r10k deploy environment #{branch} >> #{$config['mco_logfile']} 2>&1 &"
           end
           message = "triggered: #{command}"
-          Process.detach(fork{ exec "/opt/puppet/bin/mco r10k deploy #{branch} >> #{$config['mco_logfile']} 2>&1 &"})
+          Process.detach(fork{ exec "#{command}"})
         end
         $logger.info("message: #{message} branch: #{branch}")
         {:status => :success, :message => message.to_s }.to_json


### PR DESCRIPTION
We've had a couple of issues with the mcollective agent. As a short term workaround I tried changing the webhook to run r10k directly but it doesn't work without this change
