### PR TITLE
Allow prefixing to be optional

### DIFF
--- a/files/webhook
+++ b/files/webhook
@@ -86,7 +86,11 @@ class Server  < Sinatra::Base
     # If prefix is enabled in our config file run the command to determine the prefix
     if $config['prefix']
       prefix = run_prefix_command(data.to_json)
-      deploy("#{prefix}_#{branch}")
+      if prefix.empty?
+        deploy(branch)
+      else
+        deploy("#{prefix}_#{branch}")
+      end
     else
       deploy(branch)
     end


### PR DESCRIPTION
The webhook supports the ability to prefix sources in R10K. However,
this ability is an all-or-none system. When prefixing is enabled, the
webhook will attempt to join a prefix to a branch name even when no
prefix is returned from the prefix_command. In some environments, there
may be the need to deploy at least one source without a prefix.

This commit adds the ability to make prefixing, when enabled, optional.
When the prefix_command does not return a value, R10K is invoked with
the branch name only.
