### PR TITLE
Fix tests for manage_ruby_dependency => 'include'

### DIFF
--- a/spec/classes/install/gem_spec.rb
+++ b/spec/classes/install/gem_spec.rb
@@ -27,7 +27,7 @@ describe 'r10k::install::gem' , :type => 'class' do
         :manage_ruby_dependency => 'include',
         :version                => '1.1.0',
       }}
-      it { should contain_class("ruby").with('rubygems_update'   => true)}
+      it { should contain_class("ruby").with('rubygems_update'   => false)}
       it { should contain_class("ruby::dev") }
     end
     context 'when manage_ruby_dependency is set to "ignore"' do
@@ -65,7 +65,7 @@ describe 'r10k::install::gem' , :type => 'class' do
         :manage_ruby_dependency => 'include',
         :version                => '1.1.0',
       }}
-      it { should contain_class("ruby").with('rubygems_update'   => true)}
+      it { should contain_class("ruby").with('rubygems_update'   => false)}
       it { should contain_class("ruby::dev") }
     end
     context 'when manage_ruby_dependency is set to "ignore"' do
@@ -104,7 +104,7 @@ describe 'r10k::install::gem' , :type => 'class' do
         :manage_ruby_dependency => 'include',
         :version                => '0.0.9',
       }}
-      it { should contain_class("ruby").with('rubygems_update'   => true)}
+      it { should contain_class("ruby").with('rubygems_update'   => false)}
       it { should contain_class("ruby::dev") }
     end
     context 'when manage_ruby_dependency is set to "ignore"' do


### PR DESCRIPTION
The cases where manage_ruby_dependency is set to 'include' just include the ::ruby class.
They assert that the value of rubygems_update should be true, but the default value for
runbygems_update is false. Since these cases just include the class, all parameter values
will be set to their defaults, so this case should assert that rubygems_update = false.

This commit fixes these tests so that they correctly assert the default value.
