### PR TITLE
Change install_options to undef

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class r10k::params
   $version                = '1.3.4'
   $manage_modulepath      = false
   $manage_ruby_dependency = 'declare'
-  $install_options        = ''
+  $install_options        = undef
   $sources                = undef
 
   # r10k configuration


### PR DESCRIPTION
This allows it to install without gem blowing up and trying to install a
gem named ''.

Fixes #87
