### PR TITLE
Refresh webhook service when config file changes

### DIFF
--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -58,5 +58,6 @@ class r10k::webhook::config (
     mode    => '0644',
     path    => $configfile,
     content => template('r10k/webhook.yaml.erb'),
+    notify  => Service['webhook'],
   }
 }


### PR DESCRIPTION
Currently, changing the config file for the webhook doesn't result in the webhook service refreshing, and this process needs to be done manually.  This change fixes that.
