### PR TITLE
Replaced references to type() function with is_string() for Puppet 3.7.x...

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -62,7 +62,7 @@ class r10k::config (
 
   validate_bool($manage_modulepath)
 
-  if type($manage_configfile_symlink) == 'string' {
+  if is_string($manage_configfile_symlink) {
     $manage_configfile_symlink_real = str2bool($manage_configfile_symlink)
   } else {
     $manage_configfile_symlink_real = $manage_configfile_symlink

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class r10k (
 
   $ruby_dependency_options=['include','declare','ignore']
   validate_re($manage_ruby_dependency,$ruby_dependency_options)
-  if type($include_prerun_command) == 'string' {
+  if is_string($include_prerun_command) {
     $include_prerun_command_real = str2bool($include_prerun_command)
   } else {
     $include_prerun_command_real = $include_prerun_command


### PR DESCRIPTION
..., which now reserves the "type" keyword for future use
