### PR TITLE
Check for variations of $is_pe

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,7 +48,7 @@ class r10k::params
   $webhook_enable_ssl         = true
   $webhook_use_mcollective    = true
 
-  if $::is_pe =~ /true/ {
+  if $::is_pe == true or $::is_pe == 'true' {
     # Puppet Enterprise specific settings
     $puppetconf_path = '/etc/puppetlabs/puppet'
 


### PR DESCRIPTION
On recent versions of facter, we need to check for a boolean value, but
to support older versions of Facter, we need to check for a string.
