### PR TITLE
prevent potential leakage of Default {} resources

### DIFF
--- a/manifests/postrun_command.pp
+++ b/manifests/postrun_command.pp
@@ -7,13 +7,10 @@ class r10k::postrun_command (
   validate_re($ensure, [ '^present', '^absent' ],
   'ensure must be either present or absent')
 
-  Ini_setting {
-    path    => "${r10k::params::puppetconf_path}/puppet.conf",
-    ensure  => $ensure,
-    section => 'agent',
-  }
-
   ini_setting { 'r10k_postrun_command':
+    ensure  => $ensure,
+    path    => "${r10k::params::puppetconf_path}/puppet.conf",
+    section => 'agent',
     setting => 'postrun_command',
     value   => $command,
   }

--- a/manifests/prerun_command.pp
+++ b/manifests/prerun_command.pp
@@ -7,13 +7,10 @@ class r10k::prerun_command (
   validate_re($ensure, [ '^present', '^absent' ],
   'ensure must be either present or absent')
 
-  Ini_setting {
-    path    => "${r10k::params::puppetconf_path}/puppet.conf",
-    ensure  => $ensure,
-    section => 'agent',
-  }
-
   ini_setting { 'r10k_prerun_command':
+    ensure  => $ensure,
+    path    => "${r10k::params::puppetconf_path}/puppet.conf",
+    section => 'agent',
     setting => 'prerun_command',
     value   => $command,
   }


### PR DESCRIPTION
where we only have a single file, or ini_setting resource, we remove the
File {} or Ini_setting {} defaults, and put them into said resource.
This prevents potential leakage, while shrinking the code by a few of
lines.
