### PR TITLE
Handle branch names containing slashes

### DIFF
--- a/files/webhook
+++ b/files/webhook
@@ -81,7 +81,7 @@ class Server  < Sinatra::Base
     data = JSON.parse(decoded, :quirks_mode => true)
 
     # github sends a 'ref', stash sends an array in 'refChanges'
-    branch = ( data['ref'] || data['refChanges'][0]['refId'] ).split("/").last
+    branch = ( data['ref'] || data['refChanges'][0]['refId'] ).sub('refs/heads/', '')
 
     # If prefix is enabled in our config file run the command to determine the prefix
     if $config['prefix']


### PR DESCRIPTION
As per #108, the webhook doesn't properly handle branch names containing slashes.
