### PR TITLE
Added /heartbeat url endpoint to webhook

### DIFF
--- a/spec/acceptance/signature_webhook_spec.rb
+++ b/spec/acceptance/signature_webhook_spec.rb
@@ -47,9 +47,9 @@ describe 'GitHub Secret Enabled, System Ruby with No SSL, Not protected, No mcol
         expect(r.exit_code).to eq(0)
       end
     end
-    it 'should respond with a 200 with status=success in JSON format on /heartbeat' do
-      shell("/usr/bin/curl -H \"Accept: application/json\" \"http://localhost:8088/heartbeat\" -k -q") do |r|
-        expect(r.stdout).to match(/^.*success.*$/)
+    it 'should respond with success on /heartbeat' do
+      shell('/usr/bin/curl -H \"Accept: application/json\" \"http://localhost:8088/heartbeat\" -k -q') do |r|
+        expect(r.stdout).to match(%r/^.*success.*$/)
         expect(r.exit_code).to eq(0)
       end
     end

--- a/spec/acceptance/signature_webhook_spec.rb
+++ b/spec/acceptance/signature_webhook_spec.rb
@@ -47,12 +47,11 @@ describe 'GitHub Secret Enabled, System Ruby with No SSL, Not protected, No mcol
         expect(r.exit_code).to eq(0)
       end
     end
-    it 'should respond with success on /heartbeat' do
+    it '/heartbeat is successful' do
       shell('/usr/bin/curl -H \"Accept: application/json\" \"http://localhost:8088/heartbeat\" -k -q') do |r|
-        expect(r.stdout).to match(%r/^.*success.*$/)
+        expect(r.stdout).to match(%r{^.*success.*$})
         expect(r.exit_code).to eq(0)
       end
     end
-
   end
 end

--- a/spec/acceptance/signature_webhook_spec.rb
+++ b/spec/acceptance/signature_webhook_spec.rb
@@ -47,5 +47,12 @@ describe 'GitHub Secret Enabled, System Ruby with No SSL, Not protected, No mcol
         expect(r.exit_code).to eq(0)
       end
     end
+    it 'should respond with a 200 with status=success in JSON format on /heartbeat' do
+      shell("/usr/bin/curl -H \"Accept: application/json\" \"http://localhost:8088/heartbeat\" -k -q") do |r|
+        expect(r.stdout).to match(/^.*success.*$/)
+        expect(r.exit_code).to eq(0)
+      end
+    end
+
   end
 end

--- a/spec/acceptance/signature_webhook_spec.rb
+++ b/spec/acceptance/signature_webhook_spec.rb
@@ -50,7 +50,6 @@ describe 'GitHub Secret Enabled, System Ruby with No SSL, Not protected, No mcol
     it '/heartbeat is successful' do
       shell('/usr/bin/curl -H \"Accept: application/json\" \"http://localhost:8088/heartbeat\" -k -q') do |r|
         expect(r.stdout).to match(%r{^.*success.*$})
-        expect(r.exit_code).to eq(0)
       end
     end
   end

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -70,6 +70,10 @@ end
     raise Sinatra::NotFound
   end
 
+  get '/heartbeat' do
+    return 200,  {:status => :success, :message => 'running' }.to_json
+  end
+
   # Simulate a github post:
   # curl -d '{ "repository": { "name": "puppetlabs-stdlib" } }' -H "Accept: application/json" 'https://puppet:487156B2-7E67-4E1C-B447-001603C6B8B2@localhost:8088/module' -k -q
   #


### PR DESCRIPTION
Added a /heartbeat endpoint that returns 200 as long as the server is up and working... can be used to ensure server is up for load balancers and/or other HA systems. Probably most useful with mco setups.
