### PR TITLE
unbreak on OS where root group != 'root'

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -49,6 +49,8 @@ class r10k::config (
   $configfile,
   $cachedir,
   $manage_modulepath,
+  $root_user,
+  $root_group,
   $modulepath                = undef,
   $remote                    = '',
   $sources                   = 'UNSET',
@@ -95,16 +97,16 @@ class r10k::config (
   if $configfile == '/etc/puppetlabs/r10k/r10k.yaml' {
     file {'/etc/puppetlabs/r10k':
       ensure => 'directory',
-      owner  => 'root',
-      group  => 'root',
+      owner  => $root_user,
+      group  => $root_group,
       mode   => '0755',
     }
   }
 
   file { 'r10k.yaml':
     ensure  => file,
-    owner   => 'root',
-    group   => '0',
+    owner   => $root_user,
+    group   => $root_group,
     mode    => '0644',
     path    => $configfile,
     content => template($r10k_yaml_template),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,8 @@ class r10k (
   $configfile_symlink        = $r10k::params::configfile_symlink,
   $git_settings              = $r10k::params::git_settings,
   $forge_settings            = $r10k::params::forge_settings,
+  $root_user                 = $r10k::params::root_user,
+  $root_group                = $r10k::params::root_group,
   $postrun                   = undef,
   $include_prerun_command    = false,
   $include_postrun_command   = false,
@@ -71,6 +73,8 @@ class r10k (
     git_settings              => $git_settings,
     forge_settings            => $forge_settings,
     postrun                   => $postrun,
+    root_user                 => $root_user,
+    root_group                => $root_group,
   }
 
   if $mcollective {

--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -11,6 +11,8 @@ class r10k::mcollective (
   $git_ssl_no_verify = $r10k::params::mc_git_ssl_no_verify,
 ) inherits r10k::params {
 
+  require r10k
+
   $ensure_file = $ensure ? {
     true  => 'file',
     false => 'absent',
@@ -18,8 +20,8 @@ class r10k::mcollective (
 
   File {
     ensure => $ensure_file,
-    owner  => 'root',
-    group  => '0',
+    owner  => $::r10k::root_user,
+    group  => $::r10k::root_group,
     mode   => '0644',
   }
 

--- a/manifests/mcollective/application.pp
+++ b/manifests/mcollective/application.pp
@@ -7,10 +7,13 @@ class r10k::mcollective::application(
   $app_path          = $r10k::params::mc_application_path,
   $mc_service        = $r10k::params::mc_service_name,
 ) inherits r10k::params {
+
+  require r10k
+
   File {
     ensure => present,
-    owner  => 'root',
-    group  => '0',
+    owner  => $::r10k::root_user,
+    group  => $::r10k::root_group,
     mode   => '0644',
   }
   # Install the agent and its ddl file

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,32 +31,6 @@ class r10k::params
   # Include the mcollective agent
   $mcollective = false
 
-  # Webhook configuration information
-  $webhook_bind_address          = '0.0.0.0'
-  $webhook_port                  = '8088'
-  $webhook_access_logfile        = '/var/log/webhook/access.log'
-  $webhook_client_cfg            = '/var/lib/peadmin/.mcollective'
-  $webhook_use_mco_ruby          = false
-  $webhook_protected             = true
-  $webhook_github_secret         = undef
-  $webhook_discovery_timeout     = 10
-  $webhook_client_timeout        = 120
-  $webhook_prefix                = false         # ':repo' | ':user' | ':command' (or true for backwards compatibility) | 'string' | false
-  $webhook_prefix_command        = '/bin/echo example'
-  $webhook_server_software       = 'WebHook'
-  $webhook_enable_ssl            = true
-  $webhook_use_mcollective       = true
-  $webhook_r10k_deploy_arguments = '-pv'
-  $webhook_bin_template          = 'r10k/webhook.bin.erb'
-  $webhook_yaml_template         = 'r10k/webhook.yaml.erb'
-  $webhook_r10k_command_prefix   = 'umask 0022;' # 'sudo' is the canonical example for this
-  $webhook_repository_events     = undef
-  $webhook_enable_mutex_lock     = false
-  $webhook_allow_uppercase       = true          # for backwards compatibility. Default to off on a major semver update.
-  $webhook_configfile_owner      = 'root'
-  $webhook_configfile_group      = '0'
-  $webhook_configfile_mode       = '0644'
-
   if $::osfamily == 'Debian' {
     $functions_path     = '/lib/lsb/init-functions'
     $start_pidfile_args = '--pidfile=$pidfile'
@@ -105,6 +79,8 @@ class r10k::params
     $webhook_private_key_path      = '/var/lib/peadmin/.mcollective.d/peadmin-private.pem'
     $webhook_certname              = 'peadmin'
     $webhook_certpath              = '/var/lib/peadmin/.mcollective.d'
+    $root_user                     = 'root'
+    $root_group                    = 'root'
   }
   elsif $is_pe_server and versioncmp("${::puppetversion}", '4.0.0') == -1 { #lint:ignore:only_variable_string
     # PE 3.x.x specific settings
@@ -129,6 +105,8 @@ class r10k::params
     $webhook_private_key_path      = '/var/lib/peadmin/.mcollective.d/peadmin-private.pem'
     $webhook_certname              = 'peadmin'
     $webhook_certpath              = '/var/lib/peadmin/.mcollective.d'
+    $root_user                     = 'root'
+    $root_group                    = 'root'
   }
   elsif versioncmp("${::puppetversion}", '4.0.0') >= 0 { #lint:ignore:only_variable_string
     #FOSS 4 or greater specific settings
@@ -153,6 +131,8 @@ class r10k::params
     $webhook_private_key_path      = undef
     $webhook_certname              = undef
     $webhook_certpath              = undef
+    $root_user                     = 'root'
+    $root_group                    = 'root'
   }
   else {
     # Versions of FOSS prior to Puppet 4 (all in one)
@@ -180,18 +160,24 @@ class r10k::params
         $provider        = 'gem'
         $r10k_binary     = 'r10k'
         $mc_service_name = 'mcollective'
+        $root_user       = 'root'
+        $root_group      = 'root'
       }
       'gentoo': {
         $plugins_dir     = '/usr/libexec/mcollective/mcollective'
         $provider        = 'portage'
         $r10k_binary     = 'r10k'
         $mc_service_name = 'mcollective'
+        $root_user       = 'root'
+        $root_group      = 'root'
       }
       'suse': {
         $plugins_dir     = '/usr/share/mcollective/plugins/mcollective'
         $provider        = 'zypper'
         $r10k_binary     = 'r10k'
         $mc_service_name = 'mcollective'
+        $root_user       = 'root'
+        $root_group      = 'root'
       }
       'openbsd': {
         $plugins_dir     = '/usr/local/libexec/mcollective/mcollective'
@@ -201,6 +187,8 @@ class r10k::params
         } else {
           $r10k_binary     = 'r10k22'
         }
+        $root_user       = 'root'
+        $root_group      = 'wheel'
         $mc_service_name = 'mcollectived'
       }
       default: {
@@ -208,6 +196,8 @@ class r10k::params
         $provider        = 'gem'
         $r10k_binary     = 'r10k'
         $mc_service_name = 'mcollective'
+        $root_user       = 'root'
+        $root_group      = 'root'
       }
     }
   }
@@ -224,6 +214,32 @@ class r10k::params
   $mc_application_path = "${plugins_dir}/application"
   $mc_http_proxy       = undef
   $mc_git_ssl_no_verify = 0
+
+  # Webhook configuration information
+  $webhook_bind_address          = '0.0.0.0'
+  $webhook_port                  = '8088'
+  $webhook_access_logfile        = '/var/log/webhook/access.log'
+  $webhook_client_cfg            = '/var/lib/peadmin/.mcollective'
+  $webhook_use_mco_ruby          = false
+  $webhook_protected             = true
+  $webhook_github_secret         = undef
+  $webhook_discovery_timeout     = 10
+  $webhook_client_timeout        = 120
+  $webhook_prefix                = false         # ':repo' | ':user' | ':command' (or true for backwards compatibility) | 'string' | false
+  $webhook_prefix_command        = '/bin/echo example'
+  $webhook_server_software       = 'WebHook'
+  $webhook_enable_ssl            = true
+  $webhook_use_mcollective       = true
+  $webhook_r10k_deploy_arguments = '-pv'
+  $webhook_bin_template          = 'r10k/webhook.bin.erb'
+  $webhook_yaml_template         = 'r10k/webhook.yaml.erb'
+  $webhook_r10k_command_prefix   = 'umask 0022;' # 'sudo' is the canonical example for this
+  $webhook_repository_events     = undef
+  $webhook_enable_mutex_lock     = false
+  $webhook_allow_uppercase       = true          # for backwards compatibility. Default to off on a major semver update.
+  $webhook_configfile_owner      = 'root'
+  $webhook_configfile_group      = $root_group
+  $webhook_configfile_mode       = '0644'
 
   # Service Settings for SystemD in EL7
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' {

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -13,8 +13,8 @@ class r10k::webhook(
 
   File {
     ensure => $ensure,
-    owner  => 'root',
-    group  => '0',
+    owner  => $::r10k::root_user,
+    group  => $::r10k::root_group,
     mode   => '0755',
   }
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -6,6 +6,8 @@ describe 'r10k::config' , :type => 'class' do
         :configfile        => '/etc/r10k.yaml',
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => false,
+        :root_user         => 'root',
+        :root_group        => 'root',
       }
     end
     let :facts do
@@ -20,7 +22,7 @@ describe 'r10k::config' , :type => 'class' do
     it { should contain_file("r10k.yaml").with(
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'path'   => '/etc/r10k.yaml'
       )
@@ -33,6 +35,8 @@ describe 'r10k::config' , :type => 'class' do
         :configfile        => '/etc/r10k.yaml',
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => false,
+        :root_user         => 'root',
+        :root_group        => 'wheel',
       }
     end
     let :facts do
@@ -45,7 +49,7 @@ describe 'r10k::config' , :type => 'class' do
     it { should contain_file("r10k.yaml").with(
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'wheel',
         'mode'   => '0644',
         'path'   => '/etc/r10k.yaml'
       )
@@ -58,6 +62,8 @@ describe 'r10k::config' , :type => 'class' do
         :configfile        => '/etc/r10k.yaml',
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => true,
+        :root_user         => 'root',
+        :root_group        => 'root',
       }
     end
     let :facts do
@@ -72,7 +78,7 @@ describe 'r10k::config' , :type => 'class' do
     it { should contain_file("r10k.yaml").with(
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'path'   => '/etc/r10k.yaml'
       )
@@ -91,6 +97,8 @@ describe 'r10k::config' , :type => 'class' do
         :configfile        => '/etc/r10k.yaml',
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => true,
+        :root_user         => 'root',
+        :root_group        => 'wheel',
       }
     end
     let :facts do
@@ -103,7 +111,7 @@ describe 'r10k::config' , :type => 'class' do
     it { should contain_file("r10k.yaml").with(
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'wheel',
         'mode'   => '0644',
         'path'   => '/etc/r10k.yaml'
       )
@@ -123,6 +131,8 @@ describe 'r10k::config' , :type => 'class' do
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => true,
         :sources           => 'i-am-not-a-hash',
+        :root_user         => 'root',
+        :root_group        => 'root',
       }
     end
     let :facts do
@@ -144,6 +154,8 @@ describe 'r10k::config' , :type => 'class' do
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => true,
         :sources           => 'i-am-not-a-hash',
+        :root_user         => 'root',
+        :root_group        => 'wheel',
       }
     end
     let :facts do
@@ -162,6 +174,8 @@ describe 'r10k::config' , :type => 'class' do
         :configfile        => '/etc/r10k.yaml',
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => 'false-i-am-not-a-bool',
+        :root_user         => 'root',
+        :root_group        => 'root',
       }
     end
     let :facts do
@@ -182,6 +196,8 @@ describe 'r10k::config' , :type => 'class' do
         :configfile        => '/etc/r10k.yaml',
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => 'false-i-am-not-a-bool',
+        :root_user         => 'root',
+        :root_group        => 'wheel',
       }
     end
     let :facts do
@@ -204,6 +220,8 @@ describe 'r10k::config' , :type => 'class' do
             :configfile                => '/etc/puppet/r10k.yaml',
             :cachedir                  => '/var/cache/r10k',
             :manage_modulepath         => false,
+            :root_user                 => 'root',
+            :root_group                => 'root',
           }
         end
         let :facts do
@@ -230,6 +248,8 @@ describe 'r10k::config' , :type => 'class' do
             :configfile                => '/etc/puppet/r10k.yaml',
             :cachedir                  => '/var/cache/r10k',
             :manage_modulepath         => false,
+            :root_user                 => 'root',
+            :root_group                => 'wheel',
           }
         end
         let :facts do
@@ -255,6 +275,8 @@ describe 'r10k::config' , :type => 'class' do
             :configfile_symlink        => '/tmp/r10k.yaml',
             :cachedir                  => '/var/cache/r10k',
             :manage_modulepath         => false,
+            :root_user                 => 'root',
+            :root_group                => 'root',
           }
         end
         let :facts do
@@ -282,6 +304,8 @@ describe 'r10k::config' , :type => 'class' do
             :configfile_symlink        => '/tmp/r10k.yaml',
             :cachedir                  => '/var/cache/r10k',
             :manage_modulepath         => false,
+            :root_user                 => 'root',
+            :root_group                => 'wheel',
           }
         end
         let :facts do
@@ -306,6 +330,8 @@ describe 'r10k::config' , :type => 'class' do
             :configfile                => '/etc/puppet/r10k.yaml',
             :cachedir                  => '/var/cache/r10k',
             :manage_modulepath         => false,
+            :root_user                 => 'root',
+            :root_group                => 'root',
           }
         end
         let :facts do
@@ -331,6 +357,8 @@ describe 'r10k::config' , :type => 'class' do
             :configfile                => '/etc/puppet/r10k.yaml',
             :cachedir                  => '/var/cache/r10k',
             :manage_modulepath         => false,
+            :root_user                 => 'root',
+            :root_group                => 'wheel',
           }
         end
         let :facts do
@@ -356,6 +384,8 @@ describe 'r10k::config' , :type => 'class' do
             :configfile                => '/etc/puppet/r10k.yaml',
             :cachedir                  => '/var/cache/r10k',
             :manage_modulepath         => false,
+            :root_user                 => 'root',
+            :root_group                => 'root',
           }
         end
         let :facts do
@@ -376,6 +406,8 @@ describe 'r10k::config' , :type => 'class' do
             :configfile                => '/etc/puppet/r10k.yaml',
             :cachedir                  => '/var/cache/r10k',
             :manage_modulepath         => false,
+            :root_user                 => 'root',
+            :root_group                => 'wheel',
           }
         end
         let :facts do
@@ -396,6 +428,8 @@ describe 'r10k::config' , :type => 'class' do
           :configfile                => '/etc/r10k.yaml',
           :cachedir                  => '/var/cache/r10k',
           :manage_modulepath         => false,
+          :root_user                 => 'root',
+          :root_group                => 'root',
         }
       end
       let :facts do
@@ -418,6 +452,8 @@ describe 'r10k::config' , :type => 'class' do
           :configfile                => '/etc/r10k.yaml',
           :cachedir                  => '/var/cache/r10k',
           :manage_modulepath         => false,
+          :root_user                 => 'root',
+          :root_group                => 'wheel',
         }
       end
       let :facts do
@@ -442,6 +478,8 @@ describe 'r10k::config' , :type => 'class' do
           :configfile_symlink        => 'invalid/path',
           :cachedir                  => '/var/cache/r10k',
           :manage_modulepath         => false,
+          :root_user                 => 'root',
+          :root_group                => 'root',
         }
       end
       let :facts do
@@ -465,6 +503,8 @@ describe 'r10k::config' , :type => 'class' do
           :configfile_symlink        => 'invalid/path',
           :cachedir                  => '/var/cache/r10k',
           :manage_modulepath         => false,
+          :root_user                 => 'root',
+          :root_group                => 'wheel',
         }
       end
       let :facts do
@@ -487,6 +527,8 @@ describe 'r10k::config' , :type => 'class' do
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => false,
         :git_settings      => {'provider' => 'rugged','private_key' => '/root/.ssh/id_dsa'},
+        :root_user         => 'root',
+        :root_group        => 'root',
       }
     end
     it { should contain_file('r10k.yaml').with_content(%r{git:\n.*private_key: /root/\.ssh/id_dsa\n.*provider: rugged\n}) }
@@ -499,6 +541,8 @@ describe 'r10k::config' , :type => 'class' do
         :cachedir          => '/var/cache/r10k',
         :manage_modulepath => false,
         :forge_settings    => { 'proxy' => 'https://proxy.example.com:3128', 'baseurl' => 'https://forgeapi.puppetlabs.com' },
+        :root_user         => 'root',
+        :root_group        => 'root',
       }
     end
     it { should contain_file('r10k.yaml').with_content(%r{forge:\n.*baseurl: https:\/\/forgeapi\.puppetlabs\.com\n.*proxy: https:\/\/proxy\.example\.com:3128\n}) }
@@ -512,6 +556,8 @@ describe 'r10k::config' , :type => 'class' do
           :cachedir          => '/var/cache/r10k',
           :manage_modulepath => false,
           :postrun           => ['/usr/bin/curl', '-F', 'deploy=done', 'http://my-app.site/endpoint'],
+          :root_user         => 'root',
+          :root_group        => 'root',
         }
       end
       it { should contain_file('r10k.yaml').with_content(%r{^.*:postrun: \[\"/usr/bin/curl\", \"-F\", \"deploy=done\", \"http://my-app\.site/endpoint\"\]\n.*$}) }
@@ -523,6 +569,8 @@ describe 'r10k::config' , :type => 'class' do
           :configfile        => '/etc/r10k.yaml',
           :cachedir          => '/var/cache/r10k',
           :manage_modulepath => false,
+          :root_user         => 'root',
+          :root_group        => 'root',
         }
       end
       it { should contain_file('r10k.yaml').without_content(/^:postrun: .*$/) }
@@ -536,6 +584,8 @@ describe 'r10k::config' , :type => 'class' do
             :cachedir          => '/var/cache/r10k',
             :manage_modulepath => false,
             :postrun           => value,
+            :root_user         => 'root',
+            :root_group        => 'root',
           }
         end
 

--- a/spec/classes/mcollective/application_spec.rb
+++ b/spec/classes/mcollective/application_spec.rb
@@ -13,7 +13,7 @@ describe 'r10k::mcollective::application' , :type => 'class' do
     it { should contain_file("/opt/puppet/libexec/mcollective/mcollective/application/r10k.rb").with(
         'ensure' => 'present',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'source' => 'puppet:///modules/r10k/application/r10k.rb'
       )
@@ -21,7 +21,7 @@ describe 'r10k::mcollective::application' , :type => 'class' do
     it { should contain_file("/opt/puppet/libexec/mcollective/mcollective/agent/r10k.ddl").with(
         'ensure' => 'present',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'source' => 'puppet:///modules/r10k/agent/r10k.ddl'
       )
@@ -40,7 +40,7 @@ describe 'r10k::mcollective::application' , :type => 'class' do
     it { should contain_file("/usr/libexec/mcollective/mcollective/application/r10k.rb").with(
         'ensure' => 'present',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'source' => 'puppet:///modules/r10k/application/r10k.rb'
       )
@@ -48,7 +48,7 @@ describe 'r10k::mcollective::application' , :type => 'class' do
     it { should contain_file("/usr/libexec/mcollective/mcollective/agent/r10k.ddl").with(
         'ensure' => 'present',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'source' => 'puppet:///modules/r10k/agent/r10k.ddl'
       )

--- a/spec/classes/mcollective_spec.rb
+++ b/spec/classes/mcollective_spec.rb
@@ -13,14 +13,14 @@ describe 'r10k::mcollective' , :type => 'class' do
     it { should contain_file("/opt/puppet/libexec/mcollective/mcollective/application/r10k.rb").with(
         'ensure'   => 'file',
         'owner'    => 'root',
-        'group'    => '0',
+        'group'    => 'root',
         'mode'     => '0644'
       )
     }
     it { should contain_file("/opt/puppet/libexec/mcollective/mcollective/agent/r10k.ddl").with(
         'ensure'   => 'file',
         'owner'    => 'root',
-        'group'    => '0',
+        'group'    => 'root',
         'mode'     => '0644'
       )
     }
@@ -28,7 +28,7 @@ describe 'r10k::mcollective' , :type => 'class' do
     it { should contain_file("/opt/puppet/libexec/mcollective/mcollective/agent/r10k.rb").with(
         'ensure'   => 'file',
         'owner'    => 'root',
-        'group'    => '0',
+        'group'    => 'root',
         'mode'     => '0644'
       )
     }
@@ -128,14 +128,14 @@ describe 'r10k::mcollective' , :type => 'class' do
     it { should contain_file("/usr/libexec/mcollective/mcollective/application/r10k.rb").with(
         'ensure'   => 'file',
         'owner'    => 'root',
-        'group'    => '0',
+        'group'    => 'root',
         'mode'     => '0644'
       )
     }
     it { should contain_file("/usr/libexec/mcollective/mcollective/agent/r10k.ddl").with(
         'ensure'   => 'file',
         'owner'    => 'root',
-        'group'    => '0',
+        'group'    => 'root',
         'mode'     => '0644'
       )
     }
@@ -143,7 +143,7 @@ describe 'r10k::mcollective' , :type => 'class' do
     it { should contain_file("/usr/libexec/mcollective/mcollective/agent/r10k.rb").with(
         'ensure'   => 'file',
         'owner'    => 'root',
-        'group'    => '0',
+        'group'    => 'root',
         'mode'     => '0644'
       )
     }
@@ -163,7 +163,7 @@ describe 'r10k::mcollective' , :type => 'class' do
     it { should contain_file("/usr/share/mcollective/plugins/mcollective/application/r10k.rb").with(
         'ensure'   => 'file',
         'owner'    => 'root',
-        'group'    => '0',
+        'group'    => 'root',
         'mode'     => '0644'
       )
     }
@@ -171,7 +171,7 @@ describe 'r10k::mcollective' , :type => 'class' do
     it { should contain_file("/usr/share/mcollective/plugins/mcollective/agent/r10k.ddl").with(
         'ensure'   => 'file',
         'owner'    => 'root',
-        'group'    => '0',
+        'group'    => 'root',
         'mode'     => '0644'
       )
     }
@@ -179,7 +179,7 @@ describe 'r10k::mcollective' , :type => 'class' do
     it { should contain_file("/usr/share/mcollective/plugins/mcollective/agent/r10k.rb").with(
         'ensure'   => 'file',
         'owner'    => 'root',
-        'group'    => '0',
+        'group'    => 'root',
         'mode'     => '0644'
       )
     }

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -14,7 +14,7 @@ describe 'r10k::webhook::config' , :type => 'class' do
         'path'   => '/etc/webhook.yaml',
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'notify' => 'Service[webhook]'
       )
@@ -60,7 +60,7 @@ user: \"peadmin\"
         'path'   => '/etc/webhook.yaml',
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'notify' => 'Service[webhook]'
       )
@@ -108,7 +108,7 @@ user: \"puppet\"
         'path'   => '/etc/webhook.yaml',
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'notify' => 'Service[webhook]'
       )
@@ -157,7 +157,7 @@ user: \"puppet\"
         'path'   => '/etc/webhook.yaml',
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'notify' => 'Service[webhook]'
       )
@@ -206,7 +206,7 @@ user: \"puppet\"
         'path'   => '/etc/webhook.yaml',
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'notify' => 'Service[webhook]'
       )
@@ -259,7 +259,7 @@ user: \"peadmin\"
         'path'   => '/etc/webhook.yaml',
         'ensure' => 'file',
         'owner'  => 'root',
-        'group'  => '0',
+        'group'  => 'root',
         'mode'   => '0644',
         'notify' => 'Service[webhook]'
       )


### PR DESCRIPTION
Use group -> '0' for /etc/puppetlabs/r10k as well, 
as everywhere else where group 'root' is meant.
This fixes usage on OS that have group 'wheel' as root group, i.e.
OpenBSD.
