### PR TITLE
Ensure webhook run folder exists on redhat systemd environments

### DIFF
--- a/templates/webhook.redhat.service.erb
+++ b/templates/webhook.redhat.service.erb
@@ -5,6 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=forking
 EnvironmentFile=-/etc/sysconfig/webhook
+RuntimeDirectory=webhook
 User=<%= @user %>
 PIDFile=/var/run/webhook/webhook.pid
 TimeoutStartSec=90


### PR DESCRIPTION
On RHEL7, the `/run` directory is now used as a temporary file storage system (tmpfs), meaning that files there are lost after reboots.

This parameter ensures that the folder is properly created when the service starts.

This implementation relies on systemd functionality that looks appropriate in the context of this module. An alternative, as proposed [here:](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Migration_Planning_Guide/sect-Red_Hat_Enterprise_Linux-Migration_Planning_Guide-File_System_Layout.html#idp4755616), is to define a new configuration file in `/etc/tmpfiles.d/webhook.conf` with contents like:

```
D /var/run/webhook 0755 root root -
```

(Where root can be replace via template with the proper user configured in the module).
