### PR TITLE
On Puppet >= 4 the puppet binaries aren't on the webhook PATH.

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -31,7 +31,7 @@ end
 <% if @user == 'peadmin' -%>
 ENV['HOME'] = '/var/lib/<%= @user %>'
 <% end -%>
-ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>'
+ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' elsif @puppetversion >= '4.2.0' then '/opt/puppetlabs/puppet/bin' else '/usr/local/bin' end %>'
 
 $logger = WEBrick::Log::new($config['access_logfile'], WEBrick::Log::DEBUG)
 


### PR DESCRIPTION
This commit duplicates the check at the top of the file to obtain the path of the puppet binaries.
