### PR TITLE
Duplicate certpath key

### DIFF
--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -53,7 +53,6 @@ class r10k::webhook::config (
       'discovery_timeout'     => $discovery_timeout,
       'certpath'              => $certpath,
       'client_cfg'            => $client_cfg,
-      'certpath'              => $certpath,
       'use_mco_ruby'          => $use_mco_ruby,
       'access_logfile'        => $access_logfile,
       'protected'             => $protected,


### PR DESCRIPTION
`'certpath'              => $certpath` is defined twice, so I removed the second occurrence of it.

Fixes this message in puppet logs `Warning: The key 'certpath' is declared more than once` 
