### PR TITLE
Update config_version.sh

### DIFF
--- a/files/config_version.sh
+++ b/files/config_version.sh
@@ -7,16 +7,16 @@
 # Return the latest commit with the GitHub URL for it
 # The repos are placed using r10k
 
-# Get the hash of the latest commit
-sha=$(git --git-dir \
-  /etc/puppetlabs/puppet/environments/$1/.git rev-parse HEAD)
+ENVIRONMENT="$1"
+ENVIRONMENT_PATH="/etc/puppetlabs/code/environments"
 
-message=$(git --git-dir \
-  /etc/puppetlabs/puppet/environments/$1/.git log -1 --pretty='%s')
+# Get the hash of the latest commit
+sha=$(git --git-dir "/${ENVIRONMENT_PATH}/${ENVIRONMENT}/.git" rev-parse HEAD)
+
+message=$(git --git-dir "/${ENVIRONMENT_PATH}/${ENVIRONMENT}/.git" log -1 --pretty='%s')
 
 # Get the address for remote origin
-remote=$(git --git-dir \
-  /etc/puppetlabs/puppet/environments/$1/.git config --get remote.origin.url)
+remote=$(git --git-dir "/${ENVIRONMENT_PATH}/${ENVIRONMENT}/.git" config --get remote.origin.url)
 
 # Sanitize the git remote to be an http url.
 #url=$(echo "${remote}"|/bin/sed -e 's/git@//g; s/:/\//g; s/.git$//g')


### PR DESCRIPTION
I revised your example `config_version.sh` a bit. The major change is that I shortened the result of the SHA code to the first 10 characters. A complete SHA is like 40 characters. I like the cleaner output and thought others would too.

The rest of the changes are simply setting variables at the top of the file for easier configurability/readability