### PR TITLE
Fixes Puppet 4 path for webhook

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -31,7 +31,7 @@ end
 <% if @user == 'peadmin' -%>
 ENV['HOME'] = '/var/lib/<%= @user %>'
 <% end -%>
-ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:/opt/puppetlabs/bin:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>'
+ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:/opt/puppetlabs/puppet/bin:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>'
 
 $logger = WEBrick::Log::new($config['access_logfile'], WEBrick::Log::DEBUG)
 

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -31,7 +31,7 @@ end
 <% if @user == 'peadmin' -%>
 ENV['HOME'] = '/var/lib/<%= @user %>'
 <% end -%>
-ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>'
+ENV['PATH'] = '/sbin:/usr/sbin:/bin:/usr/bin:/opt/puppetlabs/bin:<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' else '/usr/local/bin' end %>'
 
 $logger = WEBrick::Log::new($config['access_logfile'], WEBrick::Log::DEBUG)
 


### PR DESCRIPTION
Resolves #273 and Resolves #280. Many thanks to @gitlabgis for finding the path issue for Puppet 4.

This is because #281 is from the github website because I was too lazy and did not fork/clone the repo and submit a proper patch.
