### PR TITLE
use puppet/make instead of deprecated croddy/make

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,7 @@ fixtures:
     ruby:    "git://github.com/puppetlabs/puppetlabs-ruby.git"
     gcc:     "git://github.com/puppetlabs/puppetlabs-gcc.git"
     pe_gem:  "git://github.com/puppetlabs/puppetlabs-pe_gem.git"
-    make:    "git://github.com/cmroddy/puppet-make.git"
+    make:    "git://github.com/voxpupuli/puppet-make.git"
     inifile: "git://github.com/puppetlabs/puppetlabs-inifile.git"
     vcsrepo: "git://github.com/puppetlabs/puppetlabs-vcsrepo.git"
     git:     "git://github.com/puppetlabs/puppetlabs-git.git"

--- a/metadata.json
+++ b/metadata.json
@@ -72,8 +72,8 @@
       "version_requirement": ">= 0.0.1"
     },
     {
-      "name": "croddy/make",
-      "version_requirement": ">= 0.0.3"
+      "name": "puppet/make",
+      "version_requirement": ">= 1.0.0"
     },
     {
       "name": "puppetlabs/inifile",

--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,7 @@
     },
     {
       "name": "puppet/make",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
This replaces references to croddy/make in metadata.json and .fixtures.yml.

I don't think it is urgent to do this, as the r10k module can still use the "old" 999.999.999 version of the make module, and the repository URL in .fixtures.yml seems to redirect correctly (first from cmroddy/make to croddy/make, and then to voxpupuli/make).