### PR TITLE
Bump puppet minimum version_requirement to 3.8.7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -94,12 +94,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": "2.7.0"
+      "version_requirement": ">=3.8.7 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet 3 versions

Also remove deprecated pe version_requirement field