### PR TITLE
(GH323) Better parameterization of root user/group from #279

### DIFF
--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -9,10 +9,9 @@ class r10k::mcollective (
   $mc_service        = $r10k::params::mc_service_name,
   $http_proxy        = $r10k::params::mc_http_proxy,
   $git_ssl_no_verify = $r10k::params::mc_git_ssl_no_verify,
+  $root_user         = $r10k::params::root_user,
+  $root_group        = $r10k::params::root_group,
 ) inherits r10k::params {
-
-  require ::r10k
-
   $ensure_file = $ensure ? {
     true  => 'file',
     false => 'absent',
@@ -20,8 +19,8 @@ class r10k::mcollective (
 
   File {
     ensure => $ensure_file,
-    owner  => $::r10k::root_user,
-    group  => $::r10k::root_group,
+    owner  => $root_user,
+    group  => $root_group,
     mode   => '0644',
   }
 

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -8,14 +8,15 @@ class r10k::webhook(
   $service_file     = $r10k::params::webhook_service_file,
   $use_mcollective  = $r10k::params::webhook_use_mcollective,
   $is_pe_server     = $r10k::params::is_pe_server,
+  $root_user        = $r10k::params::root_user,
+  $root_group       = $r10k::params::root_group,
   $manage_packages  = true,
 ) inherits r10k::params {
-  require ::r10k
 
   File {
     ensure => $ensure,
-    owner  => $::r10k::root_user,
-    group  => $::r10k::root_group,
+    owner  => $root_user,
+    group  => $root_group,
     mode   => '0755',
   }
 


### PR DESCRIPTION
Fixes #323 

The parameters `$root_user` and `$root_group` were added in #279. To do so, the main class `r10k` was required, rather than using the values from `r10k::params`, which created a conflict when using some subclasses without the main `r10k` class; specifically when replacing it with `pe_r10k`. This adjustment allows fully independent usage of `r10k::mcollective` and `r10k::webhook` again. It may require adjustment of the class parameters/hiera values, however, since the value in both classes is pulled from `r10k::params`. Heads up @buzzdeee and other users who may have overridden that value.