### PR TITLE
mcollective plugin dir has changed for foss puppet 4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -118,7 +118,7 @@ class r10k::params
 
     # Mcollective configuration dynamic
     $mc_service_name = 'mcollective'
-    $plugins_dir     = '/opt/puppetlabs/mcollective/plugins/mcollective'
+    $plugins_dir     = '/opt/puppetlabs/puppet/lib/ruby/vendor_ruby/mcollective'
     $modulepath      = undef
     $provider        = 'puppet_gem'
     $r10k_binary     = 'r10k'


### PR DESCRIPTION
The old location has no directory called plugins/mcollective. This change points the module to the location where other mcollective plugins are stored.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
