### PR TITLE
Modulesync 0.16.11 & Release 4.2.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,6 +10,8 @@ fixtures:
     inifile: "git://github.com/puppetlabs/puppetlabs-inifile.git"
     vcsrepo: "git://github.com/puppetlabs/puppetlabs-vcsrepo.git"
     git:     "git://github.com/puppetlabs/puppetlabs-git.git"
-    portage: "git://github.com/gentoo/puppet-portage.git"
+    portage:
+      repo: "git://github.com/gentoo/puppet-portage.git"
+      ref: "2.3.0"
   symlinks:
     r10k:    "#{source_dir}"

--- a/.msync.yml
+++ b/.msync.yml
@@ -1,1 +1,1 @@
-modulesync_config_version: '0.16.8'
+modulesync_config_version: '0.16.11'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -518,3 +518,7 @@ RSpec/RepeatedDescription:
 
 RSpec/NestedGroups:
   Enabled: False
+
+# disable Yaml safe_load. This is needed to support ruby2.0.0 development envs
+Security/YAMLLoad:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - bundle -v
   - rm Gemfile.lock || true
   - gem update --system
-  - gem update bundler
+  - gem install bundler -v '~>1.13.0'
   - gem --version
   - bundle -v
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not impact the functionality of the module.
 
+## [4.2.0](https://github.com/voxpupuli/puppet-r10k/tree/4.2.0) (2017-02-11)
+
+This is the last release with Puppet3 support!
+[Full Changelog](https://github.com/voxpupuli/puppet-r10k/compare/v4.1.0...4.2.0)
+
+**Closed issues:**
+
+- Add support for changing deploy settings [\#332](https://github.com/voxpupuli/puppet-r10k/issues/332)
+- Document breaking changes in CHANGELOG [\#306](https://github.com/voxpupuli/puppet-r10k/issues/306)
+- Status 42, OK, but it doesn't completely work [\#261](https://github.com/voxpupuli/puppet-r10k/issues/261)
+- \(enhancement\) pre-commit hook only validates what's on disk [\#234](https://github.com/voxpupuli/puppet-r10k/issues/234)
+
+**Merged pull requests:**
+
+- Added new 'deploy\_settings' information [\#334](https://github.com/voxpupuli/puppet-r10k/pull/334) ([triforce](https://github.com/triforce))
+- Add support for changing the 'deploy' settings in the r10k.yaml configuration file [\#333](https://github.com/voxpupuli/puppet-r10k/pull/333) ([triforce](https://github.com/triforce))
+- Added Slack webhook [\#331](https://github.com/voxpupuli/puppet-r10k/pull/331) ([jamtur01](https://github.com/jamtur01))
+- mcollective plugin dir has changed for foss puppet 4 [\#330](https://github.com/voxpupuli/puppet-r10k/pull/330) ([attachmentgenie](https://github.com/attachmentgenie))
+- Better document soft dependency abrader/gms [\#327](https://github.com/voxpupuli/puppet-r10k/pull/327) ([rnelson0](https://github.com/rnelson0))
+
 ## [v4.1.0](https://github.com/voxpupuli/puppet-r10k/tree/v4.1.0) (2017-01-06)
 [Full Changelog](https://github.com/voxpupuli/puppet-r10k/compare/v4.0.2...v4.1.0)
 
@@ -15,11 +35,10 @@ These should not impact the functionality of the module.
 
 **Merged pull requests:**
 
+- Release 4.1.0 [\#325](https://github.com/voxpupuli/puppet-r10k/pull/325) ([rnelson0](https://github.com/rnelson0))
 - \(GH323\) Better parameterization of root user/group from \#279 [\#324](https://github.com/voxpupuli/puppet-r10k/pull/324) ([rnelson0](https://github.com/rnelson0))
 - Fix rubocop failures from \#268 [\#322](https://github.com/voxpupuli/puppet-r10k/pull/322) ([rnelson0](https://github.com/rnelson0))
-- modulesync 0.16.7 [\#320](https://github.com/voxpupuli/puppet-r10k/pull/320) ([bastelfreak](https://github.com/bastelfreak))
 - Bump minimum version dependencies \(for Puppet 4\) [\#318](https://github.com/voxpupuli/puppet-r10k/pull/318) ([juniorsysadmin](https://github.com/juniorsysadmin))
-- modulesync 0.16.6 [\#317](https://github.com/voxpupuli/puppet-r10k/pull/317) ([bastelfreak](https://github.com/bastelfreak))
 - Bump puppet minimum version\_requirement to 3.8.7 [\#315](https://github.com/voxpupuli/puppet-r10k/pull/315) ([juniorsysadmin](https://github.com/juniorsysadmin))
 - \[284\] Replace hard-coded version 1.5.1 with installed [\#308](https://github.com/voxpupuli/puppet-r10k/pull/308) ([rnelson0](https://github.com/rnelson0))
 - use puppet/make instead of deprecated croddy/make [\#307](https://github.com/voxpupuli/puppet-r10k/pull/307) ([croddy](https://github.com/croddy))

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
     "mcollective",
     "r10k"
   ],
-  "version": "4.1.1-rc0",
+  "version": "4.2.0",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
@@ -77,11 +77,11 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">=1.4.1 < 2.0.0"
+      "version_requirement": ">= 1.4.1 < 2.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">=1.3.1 < 2.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "puppetlabs/git",
@@ -95,7 +95,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.8.7 < 5.0.0"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -89,7 +89,7 @@
     },
     {
       "name": "gentoo/portage",
-      "version_requirement": ">= 2.3.0 < 3.0.0"
+      "version_requirement": "2.3.0"
     }
   ],
   "requirements": [

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,8 @@ RSpec.configure do |c|
     puppetversion: Puppet.version,
     facterversion: Facter.version
   }
-  default_facts.merge!(YAML.safe_load(File.read(File.expand_path('../default_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_facts.yml', __FILE__))
-  default_facts.merge!(YAML.safe_load(File.read(File.expand_path('../default_module_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_module_facts.yml', __FILE__))
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_facts.yml', __FILE__))
+  default_facts.merge!(YAML.load(File.read(File.expand_path('../default_module_facts.yml', __FILE__)))) if File.exist?(File.expand_path('../default_module_facts.yml', __FILE__))
   c.default_facts = default_facts
 end
 


### PR DESCRIPTION
Hi @rnelson0, I would like to apply or migration thingy to this module:
https://voxpupuli.org/blog/2017/01/11/migrating-to-puppet4/

so modulesync + release 4.2.0. Then sync again. This will be the last release with puppet3 support. is that okay for you?