### PR TITLE
fix webhook systemd init script handling

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,7 @@ fixtures:
     stdlib:
       repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref:  "4.15.0"
+    systemd: "https://github.com/camptocamp/puppet-systemd.git"
     ruby:    "https://github.com/puppetlabs/puppetlabs-ruby.git"
     gcc:     "https://github.com/puppetlabs/puppetlabs-gcc.git"
     pe_gem:  "https://github.com/puppetlabs/puppetlabs-pe_gem.git"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -154,15 +154,16 @@ class r10k::params
   $webhook_webrick_version       = '1.3.1'       # Webrick 1.4 requires ruby >= 2.3
   $webhook_generate_types        = false
 
+  $webhook_service_provider      = $::service_provider
   # Service Settings for SystemD in EL7
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' {
-    $webhook_service_file     = '/usr/lib/systemd/system/webhook.service'
+    $webhook_service_file     = undef
     $webhook_service_template = 'webhook.redhat.service.erb'
   } elsif $::osfamily == 'Gentoo' {
     $webhook_service_file     = '/etc/init.d/webhook'
     $webhook_service_template = 'webhook.init.gentoo.erb'
   } elsif $::osfamily == 'Suse' and $::operatingsystemrelease >= '12' { #lint:ignore:version_comparison
-    $webhook_service_file     = '/etc/systemd/system/webhook.service'
+    $webhook_service_file     = undef
     $webhook_service_template = 'webhook.suse.service.erb'
   } else {
     $webhook_service_file     = '/etc/init.d/webhook'

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -7,6 +7,7 @@ class r10k::webhook(
   $bin_template     = $r10k::params::webhook_bin_template,
   $service_template = $r10k::params::webhook_service_template,
   $service_file     = $r10k::params::webhook_service_file,
+  $service_provider = $r10k::params::webhook_service_provider,
   $use_mcollective  = $r10k::params::webhook_use_mcollective,
   $is_pe_server     = $r10k::params::is_pe_server,
   $root_user        = $r10k::params::root_user,
@@ -64,14 +65,24 @@ class r10k::webhook(
     ensure => $ensure_directory,
     owner  => $user,
     group  => $group,
-    before => File['webhook_init_script'],
+    before => File['webhook_bin'],
   }
 
-  file { 'webhook_init_script':
-    ensure  => $ensure_file,
-    content => template("r10k/${service_template}"),
-    path    => $service_file,
-    before  => File['webhook_bin'],
+  if $service_provider == 'systemd' {
+    systemd::unit_file { 'webhook.service':
+      ensure  => $ensure_file,
+      content => template("r10k/${service_template}"),
+      require => File['webhook_bin'],
+      notify  => Service['webhook'],
+    }
+  } else {
+    file { 'webhook_init_script':
+      ensure  => $ensure_file,
+      content => template("r10k/${service_template}"),
+      path    => $service_file,
+      require => File['webhook_bin'],
+      notify  => Service['webhook'],
+    }
   }
 
   file { 'webhook_bin':
@@ -82,8 +93,9 @@ class r10k::webhook(
   }
 
   service { 'webhook':
-    ensure => $ensure_service,
-    enable => $ensure,
+    ensure   => $ensure_service,
+    enable   => $ensure,
+    provider => $service_provider,
   }
 
   # We don't remove the packages/ gem as

--- a/metadata.json
+++ b/metadata.json
@@ -53,6 +53,10 @@
   ],
   "dependencies": [
     {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 1.0.0 < 2.0.0"  
+    },
+    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.15.0 < 5.0.0"
     },

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -38,7 +38,7 @@ describe 'r10k::webhook', type: :class do
 
     it do
       is_expected.to contain_file('webhook_init_script').with(
-        path:   '/usr/lib/systemd/system/webhook.service',
+        path:   '/etc/systemd/system/webhook.service',
         content: %r{\[Unit\]}
       )
     end


### PR DESCRIPTION
This commit fixes several issues:
- systemd unit files should not have executable bit set;
- systemd has to be notified when unit file changes;
- service needs to be restarted, when init script changes ( user id, for example)
- if webhook_bin wasn't installed, webhook_init_script shouldn't either
