### PR TITLE
Adds /heartbeat url endpoint to webhook

### DIFF
--- a/spec/acceptance/signature_webhook_spec.rb
+++ b/spec/acceptance/signature_webhook_spec.rb
@@ -48,5 +48,15 @@ describe 'GitHub Secret Enabled, System Ruby with No SSL, Not protected, No mcol
         it { expect(r.exit_code).to eq(0) }
       end
     end
+    it 'responds with a 200 with status=success in JSON format on /heartbeat' do
+      shell('/usr/bin/curl -H "Accept: application/json" "http://localhost:8088/heartbeat" -k -q') do |r|
+        expect(r.stdout).to match(%r{^.*success.*$})
+        expect(r.exit_code).to eq(0)
+      end
+      shell('/usr/bin/curl -I -X GET -H "Accept: application/json" "http://localhost:8088/heartbeat" -k -q') do |r|
+        expect(r.stdout).to match(%r{^.*200 OK.*$})
+        expect(r.exit_code).to eq(0)
+      end
+    end
   end
 end

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -75,6 +75,10 @@ end
     raise Sinatra::NotFound
   end
 
+  get '/heartbeat' do
+    return 200,  {:status => :success, :message => 'running' }.to_json
+  end
+
   # Simulate a github post:
   # curl -d '{ "repository": { "name": "puppetlabs-stdlib" } }' -H "Accept: application/json" 'https://puppet:487156B2-7E67-4E1C-B447-001603C6B8B2@localhost:8088/module' -k -q
   #


### PR DESCRIPTION
* Useful to ensure server is up for loadbalancers, HA servers/proxies etc.

Rebase of #272 from @thebaron

* Params work taken out
* Commits squashed

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
