### PR TITLE
Fix webhook slack_username parameter handling

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -213,8 +213,8 @@ end
         slack_channel = '#default'
       end
 
-      if $config['slack_user']
-        slack_user = $config['slack_user']
+      if $config['slack_username']
+        slack_user = $config['slack_username']
       else
         slack_user = 'r10k'
       end


### PR DESCRIPTION
The parameter defined in the config manifests etc is slack_username, however the webhook was expecting slack_user, thus it was not being honoured.