### PR TITLE
Create sanitize_input helper method for strings sent to run_command method.

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -17,6 +17,7 @@ require 'json'
 require 'yaml'
 require 'cgi'
 require 'open3'
+require 'shellwords'
 
 WEBHOOK_CONFIG = '/etc/webhook.yaml'
 PIDFILE        = '/var/run/webhook/webhook.pid'
@@ -102,6 +103,7 @@ end
       module_name = ( data['repository']['name'] ).sub(/^.*-/, '')
     end
 
+    module_name = sanitize_input(module_name)
     deploy_module(module_name)
   end
 
@@ -156,6 +158,7 @@ end
       $config['prefix']
     end
 
+    branch = sanitize_input(branch)
     # r10k doesn't yet know how to deploy all branches from a single source.
     # The best we can do is just deploy all environments by passing nil to
     # deploy() if we don't know the correct branch.
@@ -364,6 +367,16 @@ end
           end
       end
     end #end run_prefix_command
+    
+
+    # :deploy and :deploy_module methods are vulnerable to shell
+    # injection. e.g. a branch named ";yes". Or a malicious POST request with
+    # "; rm -rf *;" as the payload. 
+    def sanitize_input(input_string)
+      sanitized = Shellwords.shellescape(input_string)
+      $logger.info("module or branch name #{sanitized} had to be escaped!") unless input_string == sanitized
+      sanitized
+    end
 
   end  #end helpers
 end


### PR DESCRIPTION
I found that this Sinatra app is vulnerable to shell injection when it runs the commands generated by the :deploy and :deploy_module methods. This patch adds a simple helper method to shell-escape this input, and is called on the strings before they're passed to the above methods. Adds no additional dependencies, Shellwords is part of the Ruby standard library.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
