### PR TITLE
Add check to fix the ruby path on puppet 4.10.0

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,4 +1,4 @@
-#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' elsif @puppetversion >= '4.2.0' or @puppetversion == '4.10.0' then '/opt/puppetlabs/puppet/bin' else '/usr/bin' end %>/ruby
+#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' elsif @puppetversion >= '4.2.0' or @puppetversion >= '4.10.0' then '/opt/puppetlabs/puppet/bin' else '/usr/bin' end %>/ruby
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster
 # Authors:

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,4 +1,4 @@
-#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' elsif @puppetversion >= '4.2.0' or @puppetversion >= '4.10.0' then '/opt/puppetlabs/puppet/bin' else '/usr/bin' end %>/ruby
+#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' elsif Puppet::Util::Package.versioncmp(Puppet.version, '4.2.0') >= 0 then '/opt/puppetlabs/puppet/bin' else '/usr/bin' end %>/ruby
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster
 # Authors:

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,4 +1,10 @@
-#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' elsif Puppet::Util::Package.versioncmp(Puppet.version, '4.2.0') >= 0 then '/opt/puppetlabs/puppet/bin' else '/usr/bin' end %>/ruby
+<% if @is_pe == true or @is_pe == 'true' -%>
+#!<%= '/opt/puppet/bin'%>/ruby
+<% elsif Puppet::Util::Package.versioncmp(Puppet.version, '4.2.0') >= 0 -%>
+#!<%= '/opt/puppetlabs/puppet/bin' %>/ruby
+<% else -%>
+#!<%= '/usr/bin' %>/ruby
+<% end -%>
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster
 # Authors:

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,9 +1,9 @@
 <% if @is_pe == true or @is_pe == 'true' -%>
-<%= '#!/opt/puppet/bin/ruby' %>
+#!/opt/puppet/bin/ruby
 <% elsif Puppet::Util::Package.versioncmp(Puppet.version, '4.2.0') >= 0 -%>
-<%= '#!/opt/puppetlabs/puppet/bin/ruby' %>
+#!/opt/puppetlabs/puppet/bin/ruby
 <% else -%>
-<%= '#!/usr/bin/ruby' %>
+#!/usr/bin/ruby
 <% end -%>
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,9 +1,9 @@
 <% if @is_pe == true or @is_pe == 'true' -%>
-#!<%= '/opt/puppet/bin'%>/ruby
+<%= '#!/opt/puppet/bin/ruby' %>
 <% elsif Puppet::Util::Package.versioncmp(Puppet.version, '4.2.0') >= 0 -%>
-#!<%= '/opt/puppetlabs/puppet/bin' %>/ruby
+<%= '#!/opt/puppetlabs/puppet/bin/ruby' %>
 <% else -%>
-#!<%= '/usr/bin' %>/ruby
+<%= '#!/usr/bin/ruby' %>
 <% end -%>
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,4 +1,4 @@
-#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' elsif @puppetversion >= '4.2.0' then '/opt/puppetlabs/puppet/bin' else '/usr/bin' end %>/ruby
+#!<%= if @is_pe == true or @is_pe == 'true' then '/opt/puppet/bin' elsif @puppetversion >= '4.2.0' or @puppetversion == '4.10.0' then '/opt/puppetlabs/puppet/bin' else '/usr/bin' end %>/ruby
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster
 # Authors:


### PR DESCRIPTION
Added a temporary check that will check if @puppetversion is >= '4.2.0'
OR == '4.10.0' and if either match, then ruby path is set to
/opt/puppetlabs/puppet/bin/ruby.

This is to get the script working properly again until a solution
can be found to ruby semver not recognizing minor release versions
greather than '9'

Closes #359 

May not be the best solution, this is just what I came up with to get it working again on our puppet master.
