### PR TITLE
Fix webhook installation by pinning sinatra gem

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,17 +1,17 @@
 fixtures:
   repositories:
     stdlib:
-      repo: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
+      repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
       ref:  "4.15.0"
-    ruby:    "git://github.com/puppetlabs/puppetlabs-ruby.git"
-    gcc:     "git://github.com/puppetlabs/puppetlabs-gcc.git"
-    pe_gem:  "git://github.com/puppetlabs/puppetlabs-pe_gem.git"
-    make:    "git://github.com/voxpupuli/puppet-make.git"
-    inifile: "git://github.com/puppetlabs/puppetlabs-inifile.git"
-    vcsrepo: "git://github.com/puppetlabs/puppetlabs-vcsrepo.git"
-    git:     "git://github.com/puppetlabs/puppetlabs-git.git"
+    ruby:    "https://github.com/puppetlabs/puppetlabs-ruby.git"
+    gcc:     "https://github.com/puppetlabs/puppetlabs-gcc.git"
+    pe_gem:  "https://github.com/puppetlabs/puppetlabs-pe_gem.git"
+    make:    "https://github.com/voxpupuli/puppet-make.git"
+    inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
+    vcsrepo: "https://github.com/puppetlabs/puppetlabs-vcsrepo.git"
+    git:     "https://github.com/puppetlabs/puppetlabs-git.git"
     portage:
-      repo: "git://github.com/gentoo/puppet-portage.git"
+      repo: "https://github.com/gentoo/puppet-portage.git"
       ref: "2.3.0"
   symlinks:
     r10k:    "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -484,6 +484,11 @@ class { '::r10k::webhook':
 }
 ```
 
+### Webhook sinatra gem installation
+
+By default, the `r10k::webhook::package` class uses the `puppet_gem` provider to install the latest ruby 2.1 compatible version of sinatra ('~> 1.0').
+If you are overriding `r10k::webhook::package::provider`, you will also need to override `r10k::webhook::package::sinatra_version`.
+
 ### Webhook Slack notifications
 
 You can enable Slack notifications for the webhook. You will need a

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -148,6 +148,7 @@ class r10k::params
   $webhook_configfile_mode       = '0644'
   $webhook_ignore_environments   = []
   $webhook_mco_arguments         = undef
+  $webhook_sinatra_version       = '~> 1.0'      # Sinatra 2 requires rack 2 which in turn requires ruby 2.2. Puppet 4 AIO ships with ruby 2.1
 
   # Service Settings for SystemD in EL7
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' {

--- a/manifests/webhook/package.pp
+++ b/manifests/webhook/package.pp
@@ -1,12 +1,13 @@
 # Private class, do not include it directly.
 # Installs the webhook packages
 class r10k::webhook::package (
-  $is_pe_server = $r10k::params::is_pe_server,
-  $provider     = $r10k::params::provider,
+  $is_pe_server    = $r10k::params::is_pe_server,
+  $provider        = $r10k::params::provider,
+  $sinatra_version = $r10k::params::webhook_sinatra_version,
 ) inherits r10k::params {
   if !defined(Package['sinatra']) {
     package { 'sinatra':
-      ensure   => installed,
+      ensure   => $sinatra_version,
       provider => $provider,
       before   => Service['webhook'],
     }

--- a/manifests/webhook/package.pp
+++ b/manifests/webhook/package.pp
@@ -11,13 +11,6 @@ class r10k::webhook::package (
       before   => Service['webhook'],
     }
   }
-  if !defined(Package['rack']) {
-    package { 'rack':
-      ensure   => installed,
-      provider => $provider,
-      before   => Service['webhook'],
-    }
-  }
   if (! $is_pe_server) {
     if !defined(Package['webrick']) {
       package { 'webrick':

--- a/spec/classes/webhook/package_spec.rb
+++ b/spec/classes/webhook/package_spec.rb
@@ -24,7 +24,6 @@ describe 'r10k::webhook::package', type: :class do
             provider: 'puppet_gem'
           )
         end
-        it { is_expected.to contain_package('rack').with(ensure: 'installed') }
         it { is_expected.not_to contain_package('webrick') }
         it { is_expected.not_to contain_package('json') }
       end
@@ -40,7 +39,6 @@ describe 'r10k::webhook::package', type: :class do
         it { is_expected.to contain_package('sinatra').with(ensure: 'installed') }
         it { is_expected.to contain_package('webrick').with(ensure: 'installed') }
         it { is_expected.to contain_package('json').with(ensure: 'installed') }
-        it { is_expected.to contain_package('rack').with(ensure: 'installed') }
       end
     end
   end

--- a/spec/classes/webhook/package_spec.rb
+++ b/spec/classes/webhook/package_spec.rb
@@ -20,7 +20,7 @@ describe 'r10k::webhook::package', type: :class do
 
         it do
           is_expected.to contain_package('sinatra').with(
-            ensure:   'installed',
+            ensure:   '~> 1.0',
             provider: 'puppet_gem'
           )
         end
@@ -36,7 +36,7 @@ describe 'r10k::webhook::package', type: :class do
           )
         end
 
-        it { is_expected.to contain_package('sinatra').with(ensure: 'installed') }
+        it { is_expected.to contain_package('sinatra').with(ensure: '~> 1.0') }
         it { is_expected.to contain_package('webrick').with(ensure: 'installed') }
         it { is_expected.to contain_package('json').with(ensure: 'installed') }
       end

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -18,12 +18,7 @@ describe 'r10k::webhook', type: :class do
           )
         end
 
-        it do
-          is_expected.to contain_package('sinatra').with(
-            ensure:   'installed',
-            provider: 'puppet_gem'
-          )
-        end
+        it { is_expected.to contain_class('r10k::webhook::package') }
         it { is_expected.not_to contain_file('peadmin-cert.pem').with(path: '/var/lib/peadmin/.mcollective.d/peadmin-cert.pem') }
       end
     end


### PR DESCRIPTION
Sinatra 2.0.0 was released on the 7th of May 2017.  It requires rack ~> 2.0 and *that* requires ruby 2.2.  Puppet 4 AIO ships with ruby 2.1, so pin sinatra to prevent errors.  I've also removed the code that managed rack installation as this was redundant.

Fixes #140