### PR TITLE
Add slack_proxy_url parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,9 +507,10 @@ Then configure the webhook to add your Slack Webhook URL.
 ```puppet
 class { '::r10k::webhook::config':
   . . .
-  slack_webhook  => 'http://slack.webhook/webhook', # mandatory for usage
-  slack_channel  => '#channel', # defaults to #default
-  slack_username => 'r10k', # the username to use
+  slack_webhook   => 'http://slack.webhook/webhook', # mandatory for usage
+  slack_channel   => '#channel', # defaults to #default
+  slack_username  => 'r10k', # the username to use
+  slack_proxy_url => 'http://proxy.example.com:3128' # Optional.  Defaults to undef.
 }
 ```
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -143,6 +143,7 @@ class r10k::params
   $webhook_slack_webhook         = undef
   $webhook_slack_channel         = undef
   $webhook_slack_username        = undef
+  $webhook_slack_proxy_url       = undef
   $webhook_configfile_owner      = 'root'
   $webhook_configfile_group      = $root_group
   $webhook_configfile_mode       = '0644'

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -36,6 +36,7 @@ class r10k::webhook::config (
   $slack_webhook                  = $r10k::params::webhook_slack_webhook,
   $slack_channel                  = $r10k::params::webhook_slack_channel,
   $slack_username                 = $r10k::params::webhook_slack_username,
+  $slack_proxy_url                = $r10k::params::webhook_slack_proxy_url,
   $configfile_owner               = $r10k::params::webhook_configfile_owner,
   $configfile_group               = $r10k::params::webhook_configfile_group,
   $configfile_mode                = $r10k::params::webhook_configfile_mode,
@@ -77,6 +78,7 @@ class r10k::webhook::config (
       'slack_webhook'         => $slack_webhook,
       'slack_channel'         => $slack_channel,
       'slack_username'        => $slack_username,
+      'slack_proxy_url'       => $slack_proxy_url,
       'ignore_environments'   => $ignore_environments,
       'mco_arguments'         => $mco_arguments,
     }

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -253,10 +253,22 @@ class Server < Sinatra::Base
         slack_user = 'r10k'
       end
 
+      if $config['slack_proxy_url']
+        uri = URI($config['slack_proxy_url'])
+        http_options = {
+                         proxy_address:  uri.hostname,
+                         proxy_port:     uri.port,
+                         proxy_from_env: false
+                       }
+      else
+        http_options = {}
+      end
+
       notifier = Slack::Notifier.new $config['slack_webhook'] do
         defaults channel: slack_channel,
                  username: slack_user,
-                 icon_emoji: ":ocean:"
+                 icon_emoji: ":ocean:",
+                 http_options: http_options
       end
 
       if status_message[:branch]


### PR DESCRIPTION
Defaults to `undef`.  When set, slack notifications will be sent via the
http proxy given.
