### PR TITLE
Generate types option

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,6 +151,7 @@ class r10k::params
   $webhook_ignore_environments   = []
   $webhook_mco_arguments         = undef
   $webhook_sinatra_version       = '~> 1.0'      # Sinatra 2 requires rack 2 which in turn requires ruby 2.2. Puppet 4 AIO ships with ruby 2.1
+  $webhook_generate_types        = false
 
   # Service Settings for SystemD in EL7
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' {

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -47,6 +47,7 @@ class r10k::webhook::config (
   $enable_mutex_lock              = $r10k::params::webhook_enable_mutex_lock,
   Array $ignore_environments      = $r10k::params::webhook_ignore_environments,
   Optional[String] $mco_arguments = $r10k::params::webhook_mco_arguments,
+  Boolean $generate_types         = $r10k::params::webhook_generate_types,
 ) inherits r10k::params {
 
   if $hash == 'UNSET' {
@@ -83,6 +84,7 @@ class r10k::webhook::config (
       'slack_proxy_url'       => $slack_proxy_url,
       'ignore_environments'   => $ignore_environments,
       'mco_arguments'         => $mco_arguments,
+      'generate_types'        => $generate_types,
     }
   } else {
     $webhook_hash = $hash

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -40,6 +40,7 @@ default_branch: "production"
 discovery_timeout: "10"
 enable_mutex_lock: false
 enable_ssl: true
+generate_types: false
 ignore_environments: []
 pass: "peadmin"
 port: "8088"
@@ -92,6 +93,7 @@ default_branch: "production"
 discovery_timeout: "10"
 enable_mutex_lock: false
 enable_ssl: true
+generate_types: false
 ignore_environments: []
 pass: "peadmin"
 port: "8088"
@@ -153,6 +155,7 @@ default_branch: "production"
 discovery_timeout: "10"
 enable_mutex_lock: false
 enable_ssl: true
+generate_types: false
 ignore_environments: []
 pass: "puppet"
 port: "8088"
@@ -197,6 +200,7 @@ default_branch: "production"
 discovery_timeout: "10"
 enable_mutex_lock: true
 enable_ssl: true
+generate_types: false
 ignore_environments: []
 pass: "puppet"
 port: "8088"
@@ -240,6 +244,7 @@ default_branch: "production"
 discovery_timeout: "10"
 enable_mutex_lock: false
 enable_ssl: true
+generate_types: false
 github_secret: "secret"
 ignore_environments: []
 pass: "puppet"
@@ -284,6 +289,7 @@ default_branch: "production"
 discovery_timeout: "10"
 enable_mutex_lock: false
 enable_ssl: true
+generate_types: false
 ignore_environments: []
 pass: "puppet"
 port: "8088"
@@ -370,6 +376,7 @@ default_branch: "production"
 discovery_timeout: "10"
 enable_mutex_lock: false
 enable_ssl: true
+generate_types: false
 ignore_environments: []
 mco_arguments: "--no-progress"
 pass: "puppet"

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -154,15 +154,6 @@ class Server < Sinatra::Base
         data['repository']['default_branch']                     # github tagged release; no ref.
       ).sub('refs/heads/', '') rescue nil
 
-    deleted = (
-      data['deleted'] || # Github
-      data['after']      # Github and Gitlab
-    )
-
-    if deleted == true || deleted == '0000000000000000000000000000000000000000'
-      branch_deleted = true
-    end
-
     # If prefix is enabled in our config file, determine what the prefix should be
     prefix = case $config['prefix']
     when :repo
@@ -177,7 +168,15 @@ class Server < Sinatra::Base
 
     # When a branch is being deleted, a deploy against it will result in a failure, as it no longer exists.
     # Instead, deploy the default branch, which will purge deleted branches per the user's configuration
-    deleted = data['deleted'] rescue false
+    branch_deleted = (
+      data['deleted'] rescue false || # Github
+      data['after']      # Github and Gitlab
+    )
+
+    if branch_deleted == true || deleted == '0000000000000000000000000000000000000000'
+      deleted = true
+    end
+
     if deleted
       branch = $config['default_branch']
     else
@@ -198,7 +197,7 @@ class Server < Sinatra::Base
       return 200
     else
       $logger.info("Deploying environment #{env}")
-      deploy(env, branch_deleted)
+      deploy(env, deleted)
     end
   end
 

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -168,9 +168,10 @@ class Server < Sinatra::Base
 
     # When a branch is being deleted, a deploy against it will result in a failure, as it no longer exists.
     # Instead, deploy the default branch, which will purge deleted branches per the user's configuration
-    branch_deleted = (
+    deleted = (
       data['deleted'] rescue false || # Github
-      data['after']      # Github and Gitlab
+      data['push']['changes'][0]['closed'] rescue false || # Bitbucket
+      data['after] rescue false     # Gitlab
     )
 
     if branch_deleted == true || deleted == '0000000000000000000000000000000000000000'

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -267,13 +267,10 @@ class Server < Sinatra::Base
         $logger.info("message: #{message} environment: #{environment}")
         status_message = {:status => :success, :message => message.to_s, :environment => environment, :status_code => 200}
         notify_slack(status_message) if slack?
-        status_message.to_json
       rescue => e
         $logger.error("message: #{e.message} trace: #{e.backtrace}")
-        status 500
         status_message = {:status => :fail, :message => e.message, :trace => e.backtrace, :environment => environment, :status_code => 500}
         notify_slack(status_message) if slack?
-        status_message.to_json
       end
     end
 

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -154,6 +154,15 @@ class Server < Sinatra::Base
         data['repository']['default_branch']                     # github tagged release; no ref.
       ).sub('refs/heads/', '') rescue nil
 
+    deleted = (
+      data['deleted'] || # Github
+      data['after']      # Github and Gitlab
+    )
+
+    if deleted == true || deleted == '0000000000000000000000000000000000000000'
+      branch_deleted = true
+    end
+
     # If prefix is enabled in our config file, determine what the prefix should be
     prefix = case $config['prefix']
     when :repo
@@ -189,7 +198,7 @@ class Server < Sinatra::Base
       return 200
     else
       $logger.info("Deploying environment #{env}")
-      deploy(env)
+      deploy(env, branch_deleted)
     end
   end
 
@@ -255,14 +264,14 @@ class Server < Sinatra::Base
         command = "#{$command_prefix} /opt/puppetlabs/bin/puppet generate types --environment #{environment}"
 
         message = run_command(command)
-        $logger.info("message: #{message} module_name: #{module_name}")
-        status_message = {:status => :success, :message => message.to_s, :module_name => module_name, :status_code => 200}
+        $logger.info("message: #{message} environment: #{environment}")
+        status_message = {:status => :success, :message => message.to_s, :environment => environment, :status_code => 200}
         notify_slack(status_message) if slack?
         status_message.to_json
       rescue => e
         $logger.error("message: #{e.message} trace: #{e.backtrace}")
         status 500
-        status_message = {:status => :fail, :message => e.message, :trace => e.backtrace, :module_name => module_name, :status_code => 500}
+        status_message = {:status => :fail, :message => e.message, :trace => e.backtrace, :environment => environment, :status_code => 500}
         notify_slack(status_message) if slack?
         status_message.to_json
       end
@@ -350,7 +359,7 @@ class Server < Sinatra::Base
       end
     end
 
-    def deploy(branch)
+    def deploy(branch, deleted)
       begin
         if $config['use_mco_ruby']
           result = mco(branch).first
@@ -370,7 +379,9 @@ class Server < Sinatra::Base
         end
         status_message =  {:status => :success, :message => message.to_s, :branch => branch, :status_code => 200}
         $logger.info("message: #{message} branch: #{branch}")
-        generate_types(branch) if types?
+        unless deleted
+          generate_types(branch) if types?
+        end
         notify_slack(status_message) if slack?
         status_message.to_json
      rescue => e

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -168,14 +168,17 @@ class Server < Sinatra::Base
 
     # When a branch is being deleted, a deploy against it will result in a failure, as it no longer exists.
     # Instead, deploy the default branch, which will purge deleted branches per the user's configuration
-    deleted = (
+    branch_deleted = (
       data['deleted'] rescue false || # Github
       data['push']['changes'][0]['closed'] rescue false || # Bitbucket
+      data['refChanges'][0]['type'] rescue false || # Stash/Bitbucket Server
       data['after] rescue false     # Gitlab
     )
 
-    if branch_deleted == true || deleted == '0000000000000000000000000000000000000000'
+    if [true, 'DELETED', '0000000000000000000000000000000000000000'].include?(branch_deleted)
       deleted = true
+    else
+      deleted = false
     end
 
     if deleted

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -382,14 +382,14 @@ class Server < Sinatra::Base
       end
     end  #end deploy()
 
-   def mco(branch)
-     options =  MCollective::Util.default_options
-     options[:config] = $config['client_cfg']
-     client = rpcclient('r10k', :exit_on_failure => false,:options => options)
-     client.discovery_timeout = $config['discovery_timeout']
-     client.timeout           = $config['client_timeout']
-     result = client.send('deploy',{:environment => branch})
-   end # end mco()
+    def mco(branch)
+      options =  MCollective::Util.default_options
+      options[:config] = $config['client_cfg']
+      client = rpcclient('r10k', :exit_on_failure => false,:options => options)
+      client.discovery_timeout = $config['discovery_timeout']
+      client.timeout           = $config['client_timeout']
+      result = client.send('deploy',{:environment => branch})
+    end # end mco()
 
     def protected!
       unless authorized?

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -250,6 +250,24 @@ class Server < Sinatra::Base
       message
     end
 
+    def generate_types(environment)
+      begin
+        command = "#{$command_prefix} /opt/puppetlabs/bin/puppet generate types --environment #{environment}"
+
+        message = run_command(command)
+        $logger.info("message: #{message} module_name: #{module_name}")
+        status_message = {:status => :success, :message => message.to_s, :module_name => module_name, :status_code => 200}
+        notify_slack(status_message) if slack?
+        status_message.to_json
+      rescue => e
+        $logger.error("message: #{e.message} trace: #{e.backtrace}")
+        status 500
+        status_message = {:status => :fail, :message => e.message, :trace => e.backtrace, :module_name => module_name, :status_code => 500}
+        notify_slack(status_message) if slack?
+        status_message.to_json
+      end
+    end
+
     def notify_slack(status_message)
       if $config['slack_channel']
         slack_channel = $config['slack_channel']
@@ -352,6 +370,7 @@ class Server < Sinatra::Base
         end
         status_message =  {:status => :success, :message => message.to_s, :branch => branch, :status_code => 200}
         $logger.info("message: #{message} branch: #{branch}")
+        generate_types(branch) if types?
         notify_slack(status_message) if slack?
         status_message.to_json
      rescue => e
@@ -390,6 +409,10 @@ class Server < Sinatra::Base
 
     def slack?
       !!$config['slack_webhook']
+    end
+
+    def types?
+      !!$config['generate_types']
     end
 
     def verify_signature(payload_body)


### PR DESCRIPTION
After running into an issue where changes in the `concat_file` type in `puppetlabs-concat` was not being picked up properly and discussing solutions/workarounds with @eputnam, I decided to add functionality to the webhook that allows the execution of `puppet generate types` on an environment after an environment deploy.

This addition adds a new setting in webhook.yaml called `generate_types`. The config option takes a Boolean value and defaults to false. If set to true, then the deploy method will also call the `generate_types` method and pass the control repo's branch name to the method which will be used for the environment parameter when `generate_types` executes the `puppet generate types` command.

For more information on `puppet generate` see https://puppet.com/docs/puppet/4.6/man/generate.html
