### PR TITLE
Pin webrick gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ If you are overriding `r10k::webhook::package::provider`, you will also need to 
 
 By default, the `r10k::webhook::package` class uses the `puppet_gem` provider to install the webrick gem (version 1.3.1)
 This version is compatible with all ruby version (webrick version 1.4.1 require Ruby version >=2.3.0)
-If you are overriding `r10k::webhook::package::provider`, you will also need to override `r10k::webhook::package::webrick_version`.
+If you are overriding `r10k::webhook::package::provider`, you may also override `r10k::webhook::package::webrick_version`.
 
 ### Webhook Slack notifications
 

--- a/README.md
+++ b/README.md
@@ -489,6 +489,12 @@ class { 'r10k::webhook':
 By default, the `r10k::webhook::package` class uses the `puppet_gem` provider to install the latest ruby 2.1 compatible version of sinatra ('~> 1.0').
 If you are overriding `r10k::webhook::package::provider`, you will also need to override `r10k::webhook::package::sinatra_version`.
 
+### Webhook webrick gem installation
+
+By default, the `r10k::webhook::package` class uses the `puppet_gem` provider to install the webrick gem (version 1.3.1)
+This version is compatible with all ruby version (webrick version 1.4.1 require Ruby version >=2.3.0)
+If you are overriding `r10k::webhook::package::provider`, you will also need to override `r10k::webhook::package::webrick_version`.
+
 ### Webhook Slack notifications
 
 You can enable Slack notifications for the webhook. You will need a

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,6 +151,7 @@ class r10k::params
   $webhook_ignore_environments   = []
   $webhook_mco_arguments         = undef
   $webhook_sinatra_version       = '~> 1.0'      # Sinatra 2 requires rack 2 which in turn requires ruby 2.2. Puppet 4 AIO ships with ruby 2.1
+  $webhook_webrick_version       = '1.3.1'       # Webrick 1.4 requires ruby >= 2.3
   $webhook_generate_types        = false
 
   # Service Settings for SystemD in EL7

--- a/manifests/webhook/package.pp
+++ b/manifests/webhook/package.pp
@@ -4,6 +4,7 @@ class r10k::webhook::package (
   $is_pe_server    = $r10k::params::is_pe_server,
   $provider        = $r10k::params::provider,
   $sinatra_version = $r10k::params::webhook_sinatra_version,
+  $webrick_version = $r10k::params::webhook_webrick_version,
 ) inherits r10k::params {
   if !defined(Package['sinatra']) {
     package { 'sinatra':
@@ -15,7 +16,7 @@ class r10k::webhook::package (
   if (! $is_pe_server) {
     if !defined(Package['webrick']) {
       package { 'webrick':
-        ensure   => installed,
+        ensure   => $webrick_version,
         provider => $provider,
         before   => Service['webhook'],
       }

--- a/spec/classes/webhook/package_spec.rb
+++ b/spec/classes/webhook/package_spec.rb
@@ -41,7 +41,7 @@ describe 'r10k::webhook::package', type: :class do
         end
 
         it { is_expected.to contain_package('sinatra').with(ensure: '~> 1.0') }
-        it { is_expected.to contain_package('webrick').with(ensure: 'installed') }
+        it { is_expected.to contain_package('webrick').with(ensure: '1.3.1') }
         it { is_expected.to contain_package('json').with(ensure: 'installed') }
       end
     end


### PR DESCRIPTION
Webrick 1.4.1 was released on the 18th of becember 2017. It requires ruby >= 2.3.0.

```
Error: /Stage[main]/R10k::Webhook::Package/Package[webrick]/ensure: change
from absent to present failed: Execution of
'/opt/puppetlabs/puppet/bin/gem install --no-rdoc --no-ri webrick'
returned 1: ERROR:  Error installing webrick: webrick requires Ruby
version >= 2.3.0
```
And the provider 'puppet_gem' has only with ruby version 2.2 (Puppet 4)
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
