### PR TITLE
Add LSB tags to the webhook init script.

### DIFF
--- a/templates/webhook.init.erb
+++ b/templates/webhook.init.erb
@@ -7,6 +7,15 @@
 #
 # description: Enables web based runs of r10k i.e. github enterprise post hooks
 # processname: webhook
+#
+### BEGIN INIT INFO
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs $network
+# Provides:          webhook
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Init script for running the r10k webhook daemon
+### END INIT INFO
 
 [ -f /etc/sysconfig/webhook ] && . /etc/sysconfig/webhook
 


### PR DESCRIPTION
This fixes the error returned when trying to run 'systemctl enable webhook' on
Ubuntu 16.04:

insserv: warning: script 'K01webhook' missing LSB tags and overrides
insserv: warning: script 'webhook' missing LSB tags and overrides
update-rc.d: error: webhook Default-Start contains no runlevels, aborting.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
