### PR TITLE
Implement locking for mcollective r10k to avoid multiple instances running in parallel

### DIFF
--- a/templates/agent/r10k.rb.erb
+++ b/templates/agent/r10k.rb.erb
@@ -22,7 +22,9 @@ module MCollective
             path = request[:path]
             reply.fail "Path not found #{path}" unless File.exists?(path)
             return unless reply.statuscode == 0
-            run_cmd act, path
+            lock do
+              run_cmd act, path
+            end
             reply[:path] = path
           end
         end
@@ -35,15 +37,21 @@ module MCollective
             if act == 'deploy'
               validate :environment, :shellsafe
               environment = request[:environment]
-              run_cmd act, environment
+              lock do
+                run_cmd act, environment
+              end
               reply[:environment] = environment
             elsif act == 'deploy_module'
               validate :module_name, :shellsafe
               module_name = request[:module_name]
-              run_cmd act, module_name
+              lock do
+                run_cmd act, module_name
+              end
               reply[:module_name] = module_name
             else
-              run_cmd act
+              lock do
+                run_cmd act
+              end
             end
           end
         end
@@ -87,6 +95,17 @@ module MCollective
               cmd << 'deploy' << 'module' << arg
             end
             reply[:status] = run(cmd_as_user(cmd), :stderr => :error, :stdout => :output, :chomp => true, :environment => environment)
+        end
+      end
+
+      def lock
+        File.open('/var/run/r10k.lock', 'w+') do |f|
+          if (not f.flock(File::LOCK_EX | File::LOCK_NB))
+            reply.fail "Another instance of r10k already running"
+            Log.info "Another instance of r10k already running"
+          else
+            yield
+          end
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

We've had several instances where one person runs r10k near same time as another using mcollective which sometimes results in entire environments getting purged and breaking puppet.  r10k itself doesn't yet support locking, https://tickets.puppetlabs.com/browse/RK-125, so implementing the locking in the mcollective agent.

This change in a test environment:

```
$ mco r10k synchronize

 * [ ============================================================> ] 1 / 1

puppet-test.DOMAIN:
Another instance of r10k already running

Finished processing 1 / 1 hosts in 10.64 ms

```