### PR TITLE
Using #to_yaml instead of printing each element

### DIFF
--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -60,18 +60,18 @@ describe 'r10k::config', type: :class do
       end
 
       context 'managing git repository settings' do
-          let :params do
-            {
-              git_settings: {
-                repositories: [{
-                  remote: 'https://github.com/voxpupuli/fake_repo',
-                  proxy: 'http://some.proxy.com'
-                }]
-              }
+        let :params do
+          {
+            git_settings: {
+              repositories: [{
+                remote: 'https://github.com/voxpupuli/fake_repo',
+                proxy: 'http://some.proxy.com'
+              }]
             }
-          end
+          }
+        end
 
-          it { is_expected.to contain_file('r10k.yaml').with_content(%r{git:\n\s+repositories:\n\s+- remote: https://github\.com/voxpupuli/fake_repo\n\s+proxy: http://some\.proxy\.com\n}) }
+        it { is_expected.to contain_file('r10k.yaml').with_content(%r{git:\n\s+repositories:\n\s+- remote: https://github\.com/voxpupuli/fake_repo\n\s+proxy: http://some\.proxy\.com\n}) }
       end
 
       context 'manage forge settings of r10k via forge_settings' do

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -56,7 +56,7 @@ describe 'r10k::config', type: :class do
           }
         end
 
-        it { is_expected.to contain_file('r10k.yaml').with_content(%r{git:\n.*private_key: /root/\.ssh/id_dsa\n.*provider: rugged\n}) }
+        it { is_expected.to contain_file('r10k.yaml').with_content(%r{git:\n.*private_key: "/root/\.ssh/id_dsa"\n.*provider: rugged\n}) }
       end
 
       context 'manage forge settings of r10k via forge_settings' do

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -59,6 +59,21 @@ describe 'r10k::config', type: :class do
         it { is_expected.to contain_file('r10k.yaml').with_content(%r{git:\n.*private_key: "/root/\.ssh/id_dsa"\n.*provider: rugged\n}) }
       end
 
+      context 'managing git repository settings' do
+          let :params do
+            {
+              git_settings: {
+                repositories: [{
+                  remote: 'https://github.com/voxpupuli/fake_repo',
+                  proxy: 'http://some.proxy.com'
+                }]
+              }
+            }
+          end
+
+          it { is_expected.to contain_file('r10k.yaml').with_content(%r{git:\n\s+repositories:\n\s+- remote: https://github\.com/voxpupuli/fake_repo\n\s+proxy: http://some\.proxy\.com\n}) }
+      end
+
       context 'manage forge settings of r10k via forge_settings' do
         let :params do
           {

--- a/templates/r10k.yaml.erb
+++ b/templates/r10k.yaml.erb
@@ -1,3 +1,10 @@
+<%
+    def settings_to_yaml(type, settings)
+      sorted_settings = settings.sort_by { |k,v| k }.to_h
+      hash = { type.to_sym => sorted_settings }
+      hash.to_yaml.gsub(/---\n/, '')
+    end
+-%>
 ---
 <% if @postrun and @postrun.is_a?(Array) -%>
 :postrun: [<%= @postrun.map{ |s| "\"#{s}\"" }.join(', ') %>]
@@ -13,20 +20,11 @@
 <% end -%>
 <% end %>
 <% if !@deploy_settings.empty? -%>
-deploy:
-<% @deploy_settings.sort.each do |key, value| -%>
-  <%=key-%>: <%=value%>
-<% end -%>
+<%= settings_to_yaml('deploy', @deploy_settings) %>
 <% end -%>
 <% if !@git_settings.empty? -%>
-git:
-<% @git_settings.sort.each do |key, value| -%>
-  <%=key-%>: <%=value%>
-<% end -%>
+<%= settings_to_yaml('git', @git_settings) %>
 <% end -%>
 <% if !@forge_settings.empty? -%>
-forge:
-<% @forge_settings.sort.each do |key, value| -%>
-  <%=key-%>: <%=value%>
-<% end -%>
+<%= settings_to_yaml('forge', @forge_settings) %>
 <% end -%>


### PR DESCRIPTION
This PR modifies the template for `r10k.yaml` to use the `#to_yaml`
method to generate valid YAML data structures from the data passed to
the template. Previously, we'd print each element assuming there would
be no nested data structures. This PR allows nested data structures to
be passed to `git_settings`, `forge_settings`, and `deploy_settings`
parameters.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
