### PR TITLE
Fixing compatibility with puppetserver/jruby.

### DIFF
--- a/templates/r10k.yaml.erb
+++ b/templates/r10k.yaml.erb
@@ -1,6 +1,9 @@
 <%
     def settings_to_yaml(type, settings)
-      sorted_settings = settings.sort_by { |k,v| k }.to_h
+      require 'yaml'
+      hash = {}
+      settings.sort.map { |k,v| hash[k] = v }
+      sorted_settings = hash 
       hash = { type.to_sym => sorted_settings }
       hash.to_yaml.gsub(/---\n/, '')
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The jruby that runs on the puppetserver does not support the array.to_h function. I am updating it to return a sorted hash that then gets converted into per the initial intent. 

It may be a good idea to add jruby to the travis test matrix. Unfortunately I am new to it and do not see it under trusty. 

#### This Pull Request (PR) fixes the following issues
https://github.com/voxpupuli/puppet-r10k/issues/421 
https://github.com/voxpupuli/puppet-r10k/issues/420
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
