### PR TITLE
wrap is_pe fact in fact() method to fail safely if it isn't present

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,6 @@
 fixtures:
   repositories:
-    stdlib:
-      repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref:  "4.15.0"
+    stdlib:  "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     ruby:    "https://github.com/puppetlabs/puppetlabs-ruby.git"
     gcc:     "https://github.com/puppetlabs/puppetlabs-gcc.git"
     pe_gem:  "https://github.com/puppetlabs/puppetlabs-pe_gem.git"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,7 @@ class r10k::params
   # We check for the function right now instead of $::pe_server_version
   # which does not get populated on agent nodes as some users use r10k
   # with razor see https://github.com/acidprime/r10k/pull/219
-  if $::is_pe == true or $::is_pe == 'true' {
+  if fact('is_pe') == true or fact('is_pe') == 'true' {
     # < PE 4
     $is_pe_server      = true
   }elsif is_function_available('pe_compiling_server_version') {

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.15.0 < 5.0.0"
+      "version_requirement": ">= 4.19.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/ruby",


### PR DESCRIPTION
From the commit message:

```
the fact() methods returns the value of a fact if it is present,
otherwise undef. This allows us to safely jump into the else block. And
that allows us to use this module as a dependency without the need to
always mock the is_pe fact.
```