### PR TITLE
provide proper default for $r10k_basedir

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,11 @@ class r10k::params
   $sources                = undef
   $puppet_master          = true
 
-  $r10k_basedir              = $facts['puppet_environmentpath']
+  if 'puppet_environment' in $facts {
+    $r10k_basedir            = $facts['puppet_environmentpath']
+  } else {
+    $r10k_basedir            = '/etc/puppetlabs/code/environments'
+  }
   $r10k_cache_dir            = "${facts['puppet_vardir']}/r10k"
   $r10k_config_file          = '/etc/puppetlabs/r10k/r10k.yaml'
   $r10k_binary               = 'r10k'


### PR DESCRIPTION
The variable basically contains the value from the
puppet_environmentpath fact. The default is
/etc/puppetlabs/code/environments. We can safely fallback to the
default value if the fact is undef. This allows the module to work
properly during the first run.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
