### PR TITLE
Replace `exec` with `Open3.capture3` to allow subsequent code to run

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -267,7 +267,7 @@ class Server < Sinatra::Base
 
         message = run_command(command)
         $logger.info("message: #{message} environment: #{environment}")
-        status_message = {:status => :success, :message => message.to_s, :environment => environment, :status_code => 200}
+        status_message = {:status => :success, :message => message.to_s, :environment => environment, :status_code => 202}
         notify_slack(status_message) if slack?
       rescue => e
         $logger.error("message: #{e.message} trace: #{e.backtrace}")
@@ -318,14 +318,14 @@ class Server < Sinatra::Base
         title: "r10k deployment of Puppet environment #{target}"
       }
 
-      case status_message[:status_code]
-      when 200
+      case status_message[:status]
+      when :success
         message.merge!(
           color: "good",
           text: "Successfully deployed #{target}",
           fallback: "Successfully deployed #{target}"
         )
-      when 500
+      when :fail
         message.merge!(
           color: "bad",
           text: "Failed to deploy #{target}",
@@ -365,14 +365,14 @@ class Server < Sinatra::Base
         title: "r10k deployment of Puppet environment #{target}",
       }
 
-      case status_message[:status_code]
-      when 200
+      case status_message[:status]
+      when :success
         attachments.merge!(
           color: "good",
           text: "Successfully deployed #{target}",
           fallback: "Successfully deployed #{target}",
         )
-      when 500
+      when :fail
         attachments.merge!(
           color: "bad",
           text: "Failed to deploy #{target}",

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -253,9 +253,9 @@ class Server < Sinatra::Base
         # the other one to complete.
         file.flock(File::LOCK_EX)
 
-        message = "triggered: #{command}"
-        exec "#{command} &"
-        exit_status = 0
+        stdout, stderr, exit_status = Open3.capture3(command)
+        message = "triggered: #{command}\n#{stdout}\n#{stderr}"
+
         raise "#{stdout}\n#{stderr}" if exit_status != 0
       end
       message

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -267,7 +267,7 @@ class Server < Sinatra::Base
 
         message = run_command(command)
         $logger.info("message: #{message} environment: #{environment}")
-        status_message = {:status => :success, :message => message.to_s, :environment => environment, :status_code => 202}
+        status_message = {:status => :success, :message => message.to_s, :environment => environment, :status_code => 200}
         notify_slack(status_message) if slack?
       rescue => e
         $logger.error("message: #{e.message} trace: #{e.backtrace}")
@@ -318,14 +318,14 @@ class Server < Sinatra::Base
         title: "r10k deployment of Puppet environment #{target}"
       }
 
-      case status_message[:status]
-      when :success
+      case status_message[:status_code]
+      when 200
         message.merge!(
           color: "good",
           text: "Successfully deployed #{target}",
           fallback: "Successfully deployed #{target}"
         )
-      when :fail
+      when 500
         message.merge!(
           color: "bad",
           text: "Failed to deploy #{target}",
@@ -365,14 +365,14 @@ class Server < Sinatra::Base
         title: "r10k deployment of Puppet environment #{target}",
       }
 
-      case status_message[:status]
-      when :success
+      case status_message[:status_code]
+      when 200
         attachments.merge!(
           color: "good",
           text: "Successfully deployed #{target}",
           fallback: "Successfully deployed #{target}",
         )
-      when :fail
+      when 500
         attachments.merge!(
           color: "bad",
           text: "Failed to deploy #{target}",

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -254,7 +254,7 @@ class Server < Sinatra::Base
         file.flock(File::LOCK_EX)
 
         stdout, stderr, exit_status = Open3.capture3(command)
-        message = "triggered: #{command}\n#{stdout}\n#{stderr}"
+        message = "triggered: #{command}"
 
         raise "#{stdout}\n#{stderr}" if exit_status != 0
       end


### PR DESCRIPTION
#### Pull Request (PR) description

This change replaces the `exec` with `Open3.capture3` as was previously used before the fork was moved to higher up in the call stack (PR #425).

#### This Pull Request (PR) fixes the following issues

Fixes #441 

