### PR TITLE
Make `status_code` entries consistent, and switch to using `status_message` for success/fail symbols

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -253,9 +253,9 @@ class Server < Sinatra::Base
         # the other one to complete.
         file.flock(File::LOCK_EX)
 
-        stdout, stderr, exit_status = Open3.capture3(command)
-        message = "triggered: #{command}\n#{stdout}\n#{stderr}"
-
+        message = "triggered: #{command}"
+        exec "#{command} &"
+        exit_status = 0
         raise "#{stdout}\n#{stderr}" if exit_status != 0
       end
       message

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -267,7 +267,7 @@ class Server < Sinatra::Base
 
         message = run_command(command)
         $logger.info("message: #{message} environment: #{environment}")
-        status_message = {:status => :success, :message => message.to_s, :environment => environment, :status_code => 200}
+        status_message = {:status => :success, :message => message.to_s, :environment => environment, :status_code => 202}
         notify_slack(status_message) if slack?
       rescue => e
         $logger.error("message: #{e.message} trace: #{e.backtrace}")
@@ -318,14 +318,14 @@ class Server < Sinatra::Base
         title: "r10k deployment of Puppet environment #{target}"
       }
 
-      case status_message[:status_code]
-      when 200
+      case status_message[:status]
+      when :success
         message.merge!(
           color: "good",
           text: "Successfully deployed #{target}",
           fallback: "Successfully deployed #{target}"
         )
-      when 500
+      when :fail
         message.merge!(
           color: "bad",
           text: "Failed to deploy #{target}",
@@ -365,14 +365,14 @@ class Server < Sinatra::Base
         title: "r10k deployment of Puppet environment #{target}",
       }
 
-      case status_message[:status_code]
-      when 200
+      case status_message[:status]
+      when :success
         attachments.merge!(
           color: "good",
           text: "Successfully deployed #{target}",
           fallback: "Successfully deployed #{target}",
         )
-      when 500
+      when :fail
         attachments.merge!(
           color: "bad",
           text: "Failed to deploy #{target}",

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -253,9 +253,9 @@ class Server < Sinatra::Base
         # the other one to complete.
         file.flock(File::LOCK_EX)
 
-        message = "triggered: #{command}"
-        exec "#{command} &"
-        exit_status = 0
+        stdout, stderr, exit_status = Open3.capture3(command)
+        message = "triggered: #{command}\n#{stdout}\n#{stderr}"
+
         raise "#{stdout}\n#{stderr}" if exit_status != 0
       end
       message

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -254,7 +254,7 @@ class Server < Sinatra::Base
         file.flock(File::LOCK_EX)
 
         stdout, stderr, exit_status = Open3.capture3(command)
-        message = "triggered: #{command}"
+        message = "triggered: #{command}\n#{stdout}\n#{stderr}"
 
         raise "#{stdout}\n#{stderr}" if exit_status != 0
       end

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -254,7 +254,7 @@ class Server < Sinatra::Base
         file.flock(File::LOCK_EX)
 
         stdout, stderr, exit_status = Open3.capture3(command)
-        message = "triggered: #{command}\n#{stdout}\n#{stderr}"
+        message = "triggered: #{command}"
 
         raise "#{stdout}\n#{stderr}" if exit_status != 0
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->
This change corrects the status_code entries to all be 202, but switches the status_message case statments to use the status field and the success/fail symbols instead of the numerical status codes. This stops it from needing to exactly match the status code.

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
n/a