### PR TITLE
Notify rocketchat in rescue of deploy environments

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -439,6 +439,7 @@ class Server < Sinatra::Base
         $logger.error("message: #{e.message} trace: #{e.backtrace}")
         status 500
         notify_slack(status_message) if slack?
+        notify_rocketchat(status_message) if rocketchat?
         status_message.to_json
       end
     end  #end deploy()


### PR DESCRIPTION
When there was an error deploying an environemnt, rocketchat was not notified (but slack was) even if rocketchat notification was configured.
This commit fixes this problem.