### PR TITLE
Handle environment name normalized by r10k

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -263,7 +263,7 @@ class Server < Sinatra::Base
 
     def generate_types(environment)
       begin
-        command = "#{$command_prefix} /opt/puppetlabs/bin/puppet generate types --environment #{environment}"
+        command = "#{$command_prefix} /opt/puppetlabs/bin/puppet generate types --environment #{environment.gsub(/\W/, '_')}"
 
         message = run_command(command)
         $logger.info("message: #{message} environment: #{environment}")


### PR DESCRIPTION
This PR adds environment name normalization for <puppet generate types> command in webhook same way as r10k does.
