### PR TITLE
Allow usage of OS r10k packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,14 @@ class { 'r10k::webhook':
 }
 ```
 
+### Webhook FOSS support using OS Ruby
+Some OS bring r10k as OS installation package. In this case you want to be able to set the ruby interpreter explizitly.
+```puppet
+class { 'r10k::webhook':
+  ruby_bin => '/usr/bin/ruby',
+}
+```
+
 ### Webhook sinatra gem installation
 
 By default, the `r10k::webhook::package` class uses the `puppet_gem` provider to install the latest ruby 2.1 compatible version of sinatra ('~> 1.0').

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -12,6 +12,7 @@ class r10k::webhook(
   $root_user        = $r10k::params::root_user,
   $root_group       = $r10k::params::root_group,
   $manage_packages  = true,
+  $ruby_bin         = undef,
 ) inherits r10k::params {
 
   File {

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -1,9 +1,13 @@
+<% if @ruby_bin -%>
+#!<%= @ruby_bin %>
+<% else -%>
 <% if @is_pe == true or @is_pe == 'true' -%>
 #!/opt/puppet/bin/ruby
 <% elsif Puppet::Util::Package.versioncmp(Puppet.version, '4.2.0') >= 0 -%>
 #!/opt/puppetlabs/puppet/bin/ruby
 <% else -%>
 #!/usr/bin/ruby
+<% end -%>
 <% end -%>
 # This mini-webserver is meant to be run as the peadmin user
 # so that it can call mcollective from a puppetmaster


### PR DESCRIPTION
Some OS - like modern Debian - have an r10k package.
In this case we want to be able to set the ruby interpreter explicitly.
