### PR TITLE
Don't run command in the background

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -258,8 +258,7 @@ class Server < Sinatra::Base
         file.flock(File::LOCK_EX)
 
         message = "triggered: #{command}"
-        exec "#{command} &"
-        exit_status = 0
+        stdout, stderr, exit_status = Open3.capture3(command)
         raise "#{stdout}\n#{stderr}" if exit_status != 0
       end
       message


### PR DESCRIPTION
#### Pull Request (PR) description
This PR replaces `exec "#{command} &"` in webhook with `Open3.capture3(command)`, since it's already running in detached forked process.

