### PR TITLE
Updates r10k location

### DIFF
--- a/files/prefix_command.rb
+++ b/files/prefix_command.rb
@@ -5,7 +5,7 @@ require 'yaml'
 if STDIN.tty?
   puts 'This command is meant be launched by webhook'
 else
-  prefixes = YAML.load_file('/etc/r10k.yaml')
+  prefixes = YAML.load_file('/etc/puppetlabs/r10k/r10k.yaml')
 
   json_data = JSON.parse(STDIN.read)
   url = json_data['repository']['url']


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

The path for r10k.yaml inside /usr/local/bin/prefix_command.rb is outdated.  This commit changes the path. I did think about making it a param but I see in  https://github.com/voxpupuli/puppet-r10k/issues/342 that the path was just hardcoded so I did the same.
