### PR TITLE
Remove `install_gcc` parameter

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,6 @@ fixtures:
   repositories:
     stdlib:  "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     ruby:    "https://github.com/puppetlabs/puppetlabs-ruby.git"
-    gcc:     "https://github.com/puppetlabs/puppetlabs-gcc.git"
     pe_gem:  "https://github.com/puppetlabs/puppetlabs-pe_gem.git"
     make:    "https://github.com/voxpupuli/puppet-make.git"
     inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
@@ -11,5 +10,3 @@ fixtures:
     portage:
       repo: "https://github.com/gentoo/puppet-portage.git"
       ref: "2.3.0"
-  symlinks:
-    r10k:    "#{source_dir}"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,15 +12,20 @@ By participating in this project you agree to abide by its terms.
 
 1. Create a separate branch for your change.
 
-1. Run the tests. We only take pull requests with passing tests, and
-   documentation.
+1. We only take pull requests with passing tests, and documentation. [travis-ci](http://travis-ci.org)
+   runs the tests for us. You can also execute them locally. This is explained
+   in a later section.
+
+1. Checkout [our docs](https://voxpupuli.org/docs/#reviewing-a-module-pr) we
+   use to review a module and the [official styleguide](https://puppet.com/docs/puppet/6.0/style_guide.html).
+   They provide some guidance for new code that might help you before you submit a pull request.
 
 1. Add a test for your change. Only refactoring and documentation
    changes require no new tests. If you are adding functionality
    or fixing a bug, please add a test.
 
 1. Squash your commits down into logical components. Make sure to rebase
-   against the current master.
+   against our current master.
 
 1. Push the branch to your fork and submit a pull request.
 
@@ -38,7 +43,9 @@ By default the tests use a baseline version of Puppet.
 If you have Ruby 2.x or want a specific version of Puppet,
 you must set an environment variable such as:
 
-    export PUPPET_VERSION="~> 4.2.0"
+```sh
+export PUPPET_VERSION="~> 5.5.6"
+```
 
 You can install all needed gems for spec tests into the modules directory by
 running:
@@ -65,13 +72,17 @@ The test suite will run [Puppet Lint](http://puppet-lint.com/) and
 [Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
 check various syntax and style things. You can run these locally with:
 
-    bundle exec rake lint
-    bundle exec rake validate
+```sh
+bundle exec rake lint
+bundle exec rake validate
+```
 
 It will also run some [Rubocop](http://batsov.com/rubocop/) tests
 against it. You can run those locally ahead of time with:
 
-    bundle exec rake rubocop
+```sh
+bundle exec rake rubocop
+```
 
 ## Running the unit tests
 
@@ -82,15 +93,21 @@ about how best to test your new feature.
 
 To run the linter, the syntax checker and the unit tests:
 
-    bundle exec rake test
+```sh
+bundle exec rake test
+```
 
 To run your all the unit tests
 
-    bundle exec rake spec SPEC_OPTS='--format documentation'
+```sh
+bundle exec rake spec
+```
 
 To run a specific spec test set the `SPEC` variable:
 
-    bundle exec rake spec SPEC=spec/foo_spec.rb
+```sh
+bundle exec rake spec SPEC=spec/foo_spec.rb
+```
 
 ## Integration tests
 
@@ -102,23 +119,51 @@ This fires up a new virtual machine (using vagrant) and runs a series of
 simple tests against it after applying the module. You can run this
 with:
 
-    bundle exec rake acceptance
+```sh
+bundle exec rake acceptance
+```
 
 This will run the tests on the module's default nodeset. You can override the
 nodeset used, e.g.,
 
-    BEAKER_set=centos-7-x64 bundle exec rake acceptance
+```sh
+BEAKER_set=centos-7-x64 bundle exec rake acceptance
+```
 
 There are default rake tasks for the various acceptance test modules, e.g.,
 
-    bundle exec rake beaker:centos-7-x64
-    bundle exec rake beaker:ssh:centos-7-x64
+```sh
+bundle exec rake beaker:centos-7-x64
+bundle exec rake beaker:ssh:centos-7-x64
+```
 
 If you don't want to have to recreate the virtual machine every time you can
 use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will at
 least need `BEAKER_provision` set to yes (the default). The Vagrantfile for the
 created virtual machines will be in `.vagrant/beaker_vagrant_files`.
 
+Beaker also supports docker containers. We also use that in our automated CI
+pipeline at [travis-ci](http://travis-ci.org). To use that instead of Vagrant:
+
+```
+PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian9-64{hypervisor=docker} BEAKER_destroy=yes bundle exec rake beaker
+```
+
+You can replace the string `debian9` with any common operating system.
+The following strings are known to work:
+
+* ubuntu1604
+* ubuntu1804
+* debian8
+* debian9
+* centos6
+* centos7
+
 The easiest way to debug in a docker container is to open a shell:
 
-    docker exec -it -u root ${container_id_or_name} bash
+```sh
+docker exec -it -u root ${container_id_or_name} bash
+```
+
+The source of this file is in our [modulesync_config](https://github.com/voxpupuli/modulesync_config/blob/master/moduleroot/.github/CONTRIBUTING.md.erb)
+repository.

--- a/.msync.yml
+++ b/.msync.yml
@@ -1,1 +1,1 @@
-modulesync_config_version: '2.0.0'
+modulesync_config_version: '2.1.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ matrix:
     env: PUPPET_VERSION="~> 5.0" CHECK=test
   - rvm: 2.5.1
     bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 5.0" CHECK=test_with_coveralls
-  - rvm: 2.4.4
-    bundler_args: --without system_tests development release
-    env: PUPPET_VERSION="~> 5.0" CHECK=rubocop
+    env: PUPPET_VERSION="~> 6.0" CHECK=test_with_coveralls
   - rvm: 2.5.1
+    bundler_args: --without system_tests development release
+    env: PUPPET_VERSION="~> 6.0" CHECK=rubocop
+  - rvm: 2.4.4
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
 branches:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v6.7.0](https://github.com/voxpupuli/puppet-r10k/tree/v6.7.0) (2018-10-13)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-r10k/compare/v6.6.1...v6.7.0)
+
+**Implemented enhancements:**
+
+- Allow usage of OS r10k packages [\#453](https://github.com/voxpupuli/puppet-r10k/pull/453) ([tuxmea](https://github.com/tuxmea))
+
+**Fixed bugs:**
+
+- Handle environment name normalized by r10k [\#452](https://github.com/voxpupuli/puppet-r10k/pull/452) ([sapakt](https://github.com/sapakt))
+
+**Merged pull requests:**
+
+- allow puppet 6.x [\#454](https://github.com/voxpupuli/puppet-r10k/pull/454) ([bastelfreak](https://github.com/bastelfreak))
+- allow puppetlabs/stdlib 5.x [\#450](https://github.com/voxpupuli/puppet-r10k/pull/450) ([bastelfreak](https://github.com/bastelfreak))
+
 ## [v6.6.1](https://github.com/voxpupuli/puppet-r10k/tree/v6.6.1) (2018-07-29)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-r10k/compare/v6.6.0...v6.6.1)

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'puppetlabs_spec_helper', '~> 2.6',                           :require => false
-  gem 'rspec-puppet', '~> 2.5',                                     :require => false
+  gem 'puppetlabs_spec_helper', '>= 2.11.0',                        :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,6 @@ class r10k (
   $postrun                                                    = undef,
   Boolean $include_prerun_command                             = false,
   Boolean $include_postrun_command                            = false,
-  Boolean $install_gcc                                        = false,
 ) inherits r10k::params {
 
   # Check if user is declaring both classes
@@ -52,7 +51,6 @@ class r10k (
     provider               => $provider,
     version                => $version,
     puppet_master          => $puppet_master,
-    install_gcc            => $install_gcc,
   }
 
   class { '::r10k::config':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,18 +8,7 @@ class r10k::install (
   $manage_ruby_dependency,
   $puppet_master = true,
   $is_pe_server = $r10k::params::is_pe_server,
-  $install_gcc = false,
 ) inherits r10k::params {
-
-  # There are currently bugs in r10k 1.x which make using 0.x desireable in
-  # certain circumstances. However, 0.x requires make and gcc. Conditionally
-  # include those classes if necessary due to 0.x r10k version usage. When
-  # 1.x is just as good or better than 0.x, we can stop supporting 0.x and
-  # remove this block.
-  if versioncmp('1.0.0', $version) > 0 or $install_gcc {
-    require ::gcc
-    require ::make
-  }
 
   if $package_name == '' {
     case $provider {

--- a/manifests/install/gem.pp
+++ b/manifests/install/gem.pp
@@ -27,20 +27,4 @@ class r10k::install::gem (
       #do nothing
     }
   }
-
-  # Explicit dependency chaining to make sure the system is ready to compile
-  # native extentions for dependent rubygems by the time r10k installation
-  # begins
-  if versioncmp('1.0.0', $version) > 0 {
-    # I am not sure all of this is required as I assumed the
-    # ruby::dev class would have taken care of some of it
-    include ::make
-    include ::gcc
-
-    Anchor['r10k::ruby_done']
-    -> Class['gcc']
-    -> Class['make']
-    -> Package['r10k']
-  }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "author": "Vox Pupuli",
   "license": "Apache-2.0",
   "name": "puppet-r10k",
-  "version": "6.6.2-rc0",
+  "version": "6.7.1-rc0",
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
@@ -60,14 +60,6 @@
       "version_requirement": ">= 0.6.0 < 2.0.0"
     },
     {
-      "name": "puppetlabs/gcc",
-      "version_requirement": ">= 0.3.0 < 2.0.0"
-    },
-    {
-      "name": "puppet/make",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
-    },
-    {
       "name": "puppetlabs/inifile",
       "version_requirement": ">= 1.4.1 < 3.0.0"
     },
@@ -87,7 +79,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.10.0 < 6.0.0"
+      "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ]
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -26,7 +26,6 @@ describe 'r10k::install', type: :class do
 
         # New versions of this gem do not require these packages
         it { is_expected.not_to contain_class('make') }
-        it { is_expected.not_to contain_package('gcc') }
 
         it { is_expected.to contain_class('r10k::install::gem').with(version: version) }
         it do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Currently r10k requires puppetlabs/gcc which hasn't been updated in almost 4 years in turns only allows up to stdlib version <5.0.0. There are certain features which we would really like to use in 5x but can't. 
I'm not too sure about upgrading GCC but while I was poking around in the code base I found the following comment which indicated that GCC should have been removed once r10k it version 1.0
```
 # There are currently bugs in r10k 1.x which make using 0.x desireable in
  # certain circumstances. However, 0.x requires make and gcc. Conditionally
  # include those classes if necessary due to 0.x r10k version usage. When
  # 1.x is just as good or better than 0.x, we can stop supporting 0.x and
  # remove this block.
```
I'm hoping that since r10k is now at version 3 and no longer requires GCC or make that this PR will be accepted.  Alternatively we could try and get GCC moved to voxpupuli and I could have a go at upgrading but this seems like a much shorted path to victory :smile:  