### PR TITLE
Identify branch name from BitBucket server native webhook payload

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -158,6 +158,7 @@ class Server < Sinatra::Base
         data['ref']                                          ||  # github & gitlab
         data['refChanges'][0]['refId']            rescue nil ||  # stash
         data['push']['changes'][0]['new']['name'] rescue nil ||  # bitbucket
+        data['changes'][0]['ref']['displayId']    rescue nil ||  # bitbucket server native
         data['resource']['refUpdates'][0]['name'] rescue nil ||  # TFS/VisualStudio-Git
         data['repository']['default_branch']                     # github tagged release; no ref.
       ).sub('refs/heads/', '') rescue nil


### PR DESCRIPTION
#### Pull Request (PR) description
Adding support for locating the branch name from BitBucket server native webhook payload to determine r10k deployment environment.

#### This Pull Request (PR) fixes the following issues
Fixes #436
