### PR TITLE
Removes gcc and make

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,7 @@ fixtures:
   repositories:
     stdlib:  "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     ruby:    "https://github.com/puppetlabs/puppetlabs-ruby.git"
-    gcc:     "https://github.com/puppetlabs/puppetlabs-gcc.git"
     pe_gem:  "https://github.com/puppetlabs/puppetlabs-pe_gem.git"
-    make:    "https://github.com/voxpupuli/puppet-make.git"
     inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
     vcsrepo: "https://github.com/puppetlabs/puppetlabs-vcsrepo.git"
     git:     "https://github.com/puppetlabs/puppetlabs-git.git"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,6 @@ class r10k (
   $postrun                                                    = undef,
   Boolean $include_prerun_command                             = false,
   Boolean $include_postrun_command                            = false,
-  Boolean $install_gcc                                        = false,
 ) inherits r10k::params {
 
   # Check if user is declaring both classes
@@ -52,7 +51,6 @@ class r10k (
     provider               => $provider,
     version                => $version,
     puppet_master          => $puppet_master,
-    install_gcc            => $install_gcc,
   }
 
   class { '::r10k::config':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,18 +8,7 @@ class r10k::install (
   $manage_ruby_dependency,
   $puppet_master = true,
   $is_pe_server = $r10k::params::is_pe_server,
-  $install_gcc = false,
 ) inherits r10k::params {
-
-  # There are currently bugs in r10k 1.x which make using 0.x desireable in
-  # certain circumstances. However, 0.x requires make and gcc. Conditionally
-  # include those classes if necessary due to 0.x r10k version usage. When
-  # 1.x is just as good or better than 0.x, we can stop supporting 0.x and
-  # remove this block.
-  if versioncmp('1.0.0', $version) > 0 or $install_gcc {
-    require ::gcc
-    require ::make
-  }
 
   if $package_name == '' {
     case $provider {

--- a/manifests/install/gem.pp
+++ b/manifests/install/gem.pp
@@ -27,20 +27,4 @@ class r10k::install::gem (
       #do nothing
     }
   }
-
-  # Explicit dependency chaining to make sure the system is ready to compile
-  # native extentions for dependent rubygems by the time r10k installation
-  # begins
-  if versioncmp('1.0.0', $version) > 0 {
-    # I am not sure all of this is required as I assumed the
-    # ruby::dev class would have taken care of some of it
-    include ::make
-    include ::gcc
-
-    Anchor['r10k::ruby_done']
-    -> Class['gcc']
-    -> Class['make']
-    -> Package['r10k']
-  }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -60,14 +60,6 @@
       "version_requirement": ">= 0.6.0 < 2.0.0"
     },
     {
-      "name": "puppetlabs/gcc",
-      "version_requirement": ">= 0.3.0 < 2.0.0"
-    },
-    {
-      "name": "puppet/make",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
-    },
-    {
       "name": "puppetlabs/inifile",
       "version_requirement": ">= 1.4.1 < 3.0.0"
     },

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -24,10 +24,6 @@ describe 'r10k::install', type: :class do
 
         it { is_expected.to contain_class('git') }
 
-        # New versions of this gem do not require these packages
-        it { is_expected.not_to contain_class('make') }
-        it { is_expected.not_to contain_package('gcc') }
-
         it { is_expected.to contain_class('r10k::install::gem').with(version: version) }
         it do
           is_expected.to contain_package('r10k').with(


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Currently, r10k requires puppetlabs/gcc which hasn't been updated in almost 4 years in turns only allows up to stdlib version <5.0.0. There are certain features which we would really like to use in 5x but can't.
I'm not too sure about upgrading GCC but while I was poking around in the code base I found the following comment which indicated that GCC should have been removed once r10k it version 1.0

```
 # There are currently bugs in r10k 1.x which make using 0.x desireable in
  # certain circumstances. However, 0.x requires make and gcc. Conditionally
  # include those classes if necessary due to 0.x r10k version usage. When
  # 1.x is just as good or better than 0.x, we can stop supporting 0.x and
  # remove this block.
```
This is a breaking change but according to the puppet-r10k version chart, the current version of puppet-r10k supports the r10k v.3.0.3 gem which no longer requires gcc or make so I dont think this should be a blocker.