### PR TITLE
WIP: This PR removes the hard-coded value for the prefix_command configfile

### DIFF
--- a/examples/webhook/config.pp
+++ b/examples/webhook/config.pp
@@ -1,11 +1,11 @@
 include ::r10k::webhook
 
 file {'/usr/local/bin/prefix_command.rb':
-  ensure => file,
-  mode   => '0755',
-  owner  => 'root',
-  group  => '0',
-  source => 'puppet:///modules/r10k/prefix_command.rb',
+  ensure  => file,
+  mode    => '0755',
+  owner   => 'root',
+  group   => '0',
+  content => template('puppet-r10k/prefix_command.erb'),
 }
 
 class {'::r10k::webhook::config':

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -1,5 +1,6 @@
 # This class creates a github webhoook to allow curl style post-rec scripts
 class r10k::webhook(
+  $configfile       = $r10k::params::r10k_config_file,
   $ensure           = true,
   $user             = $r10k::params::webhook_user,
   $group            = $r10k::params::webhook_group,

--- a/spec/acceptance/prefix_webhook_spec.rb
+++ b/spec/acceptance/prefix_webhook_spec.rb
@@ -9,7 +9,7 @@ describe 'Prefix Enabled,System Ruby with No SSL, Not protected, No mcollective'
         mode   => '0755',
         owner  => 'root',
         group  => '0',
-        source => 'puppet:///modules/r10k/prefix_command.rb',
+        content => template('puppet-r10k/prefix_command.erb'),
       }
       class { 'r10k':
         sources => {

--- a/templates/prefix_command.rb.erb
+++ b/templates/prefix_command.rb.erb
@@ -5,7 +5,7 @@ require 'yaml'
 if STDIN.tty?
   puts 'This command is meant be launched by webhook'
 else
-  prefixes = YAML.load_file('/etc/r10k.yaml')
+  prefixes = YAML.load_file(<%= @configfile %>)
 
   json_data = JSON.parse(STDIN.read)
   url = json_data['repository']['url']


### PR DESCRIPTION
file value.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR removes the hard-coded value for the prefix_command  by moving the prefix_command file resource to a template and then using the $configfile param which is defaulted to `/etc/puppetlabs/r10k/r10k.yaml`.
