### PR TITLE
Acceptance tests run requests in parallel commented

### DIFF
--- a/spec/acceptance/basic_webhook_spec.rb
+++ b/spec/acceptance/basic_webhook_spec.rb
@@ -1,61 +1,65 @@
 require 'spec_helper_acceptance'
 
 describe 'System Ruby with No SSL, Not protected, No mcollective' do
-  context 'default parameters' do
-    pp = %(
-      class { 'r10k':
-        remote => 'git@github.com:someuser/puppet.git',
-      }
-      class {'r10k::webhook::config':
-        enable_ssl      => false,
-        protected       => false,
-        use_mcollective => false,
-        notify     => Service['webhook'],
-      }
+  context 'with basics parameters' do
+    hosts_as('agent').each do |agent|
+      it 'applies with no errors and idempotently' do
+        pp = %(
+          class { 'r10k':
+            remote => 'git@github.com:someuser/puppet.git',
+          }
+          class {'r10k::webhook::config':
+            enable_ssl      => false,
+            protected       => false,
+            use_mcollective => false,
+            notify     => Service['webhook'],
+          }
 
-      class {'r10k::webhook':
-        require => Class['r10k::webhook::config'],
-      }
-    )
+          class {'r10k::webhook':
+            require => Class['r10k::webhook::config'],
+          }
+        )
 
-    it 'applies with no errors' do
-      apply_manifest(pp, catch_failures: true)
-    end
-    it 'is idempotent' do
-      apply_manifest(pp, catch_changes: true)
-    end
-    describe service('webhook') do
-      it { is_expected.to be_enabled }
-      it { is_expected.to be_running }
-    end
-    describe command('/usr/bin/curl -d \'{ "repository": { "name": "puppetlabs-stdlib" } }\' -H "Accept: application/json" "http://localhost:8088/module" -k -q') do
-      its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
-      its(:exit_status) { is_expected.to eq 0 }
-    end
-    describe command('/usr/bin/curl -X POST -d \'{ "repository": { "full_name": "puppetlabs/puppetlabs-stdlib", "name": "PuppetLabs : StdLib" } }\' "http://localhost:8088/module" -k -q') do
-      its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
-      its(:exit_status) { is_expected.to eq 0 }
-    end
-    describe command('/usr/bin/curl -d \'{ "ref": "refs/heads/production" }\' -H "Accept: application/json" "http://localhost:8088/payload" -k -q') do
-      its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
-      its(:exit_status) { is_expected.to eq 0 }
-    end
-    describe command('/usr/bin/curl -X POST -d \'%7b%22ref%22%3a%22maste%r22%7d\' "http://localhost:8088/payload" -q') do
-      its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
-      its(:exit_status) { is_expected.to eq 0 }
-    end
-    describe command('/usr/bin/curl -X POST -d \'{ "push": { "changes": [ { "new": { "name": "production" } } ] } }\' "http://localhost:8088/payload" -q') do
-      its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
-      its(:exit_status) { is_expected.to eq 0 }
-    end
-
-    4.times do
-      Thread.new do
-        describe command('/usr/bin/curl -d \'{ "ref": "refs/heads/production" }\' -H "Accept: application/json" "http://localhost:8088/payload" -k -q') do
-          its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
-          its(:exit_status) { is_expected.to eq 0 }
-        end
+        apply_manifest_on(agent, pp, catch_failures: true)
+        apply_manifest_on(agent, pp, catch_changes: true)
       end
+
+      describe service('webhook') do
+        it { is_expected.to be_enabled }
+        it { is_expected.to be_running }
+      end
+      describe command('/usr/bin/curl -d \'{ "repository": { "name": "puppetlabs-stdlib" } }\' -H "Accept: application/json" "http://localhost:8088/module" -k -q') do
+        its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
+        its(:exit_status) { is_expected.to eq 0 }
+      end
+      describe command('/usr/bin/curl -X POST -d \'{ "repository": { "full_name": "puppetlabs/puppetlabs-stdlib", "name": "PuppetLabs : StdLib" } }\' "http://localhost:8088/module" -k -q') do
+        its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
+        its(:exit_status) { is_expected.to eq 0 }
+      end
+      describe command('/usr/bin/curl -d \'{ "ref": "refs/heads/production" }\' -H "Accept: application/json" "http://localhost:8088/payload" -k -q') do
+        its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
+        its(:exit_status) { is_expected.to eq 0 }
+      end
+      describe command('/usr/bin/curl -X POST -d \'%7b%22ref%22%3a%22maste%r22%7d\' "http://localhost:8088/payload" -q') do
+        its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
+        its(:exit_status) { is_expected.to eq 0 }
+      end
+      describe command('/usr/bin/curl -X POST -d \'{ "push": { "changes": [ { "new": { "name": "production" } } ] } }\' "http://localhost:8088/payload" -q') do
+        its(:stdout) { is_expected.not_to match %r{.*You shall not pass.*} }
+        its(:exit_status) { is_expected.to eq 0 }
+      end
+      # Following test is let here commented to rememeber it.
+      #   * it does not work as is.
+      #   * it is interesting to add this tests when possible.
+      #
+      #      it 'successfully locks when hammered with multiple requests' do
+      #        4.times do
+      #          Thread.new do
+      #            result = on(agent, '/usr/bin/curl -d \'{ "ref": "refs/heads/production" }\' -H "Accept: application/json" "http://localhost:8088/payload" -k -q')
+      #            result.exit_code.should == 0
+      #          end
+      #        end
+      #      end
     end
   end
 end

--- a/spec/acceptance/signature_webhook_spec.rb
+++ b/spec/acceptance/signature_webhook_spec.rb
@@ -31,7 +31,7 @@ describe 'GitHub Secret Enabled, System Ruby with No SSL, Not protected, No mcol
     end
 
     context 'supports style Github payloads via module end point with signature in header' do
-      HMAC_DIGEST = OpenSSL::Digest::Digest.new('sha1')
+      HMAC_DIGEST = OpenSSL::Digest.new('sha1')
       signature = 'sha1=' + OpenSSL::HMAC.hexdigest(HMAC_DIGEST, 'secret', '{ "repository": { "name": "puppetlabs-stdlib" } }')
 
       describe command("/usr/bin/curl -d '{ \"repository\": { \"name\": \"puppetlabs-stdlib\" } }' -H \"Accept: application/json\" \"http://localhost:8088/module\" -H \"X-Hub-Signature: #{signature}\" -k -q") do
@@ -40,7 +40,7 @@ describe 'GitHub Secret Enabled, System Ruby with No SSL, Not protected, No mcol
       end
     end
     context 'supports style Github payloads via payload end point with signature in header' do
-      HMAC_DIGEST = OpenSSL::Digest::Digest.new('sha1')
+      HMAC_DIGEST = OpenSSL::Digest.new('sha1')
       signature = 'sha1=' + OpenSSL::HMAC.hexdigest(HMAC_DIGEST, 'secret', '{ "ref": "refs/heads/production" }')
 
       describe command("/usr/bin/curl -d '{ \"ref\": \"refs/heads/production\" }' -H \"Accept: application/json\" -H \"X-Hub-Signature: #{signature}\" \"http://localhost:8088/payload\" -k -q") do


### PR DESCRIPTION

#### Pull Request (PR) description

This is a WIP task that wish to fix a test about webhook ability to handle concurrency when hammered with multiple requests. 

The comment in a previous PR from @ekohl is confirmed : describe blocks are run separate.
https://github.com/voxpupuli/puppet-r10k/pull/469#pullrequestreview-180581469

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
