### PR TITLE
set webrick and sinatra versions to 'installed'

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,14 +530,8 @@ class { 'r10k::webhook':
 
 ### Webhook sinatra gem installation
 
-By default, the `r10k::webhook::package` class uses the `puppet_gem` provider to install the latest ruby 2.1 compatible version of sinatra ('~> 1.0').
+By default, the `r10k::webhook::package` class uses the `puppet_gem` provider to install the latest version of sinatra.
 If you are overriding `r10k::webhook::package::provider`, you will also need to override `r10k::webhook::package::sinatra_version`.
-
-### Webhook webrick gem installation
-
-By default, the `r10k::webhook::package` class uses the `puppet_gem` provider to install the webrick gem (version 1.3.1)
-This version is compatible with all ruby version (webrick version 1.4.1 require Ruby version >=2.3.0)
-If you are overriding `r10k::webhook::package::provider`, you may also override `r10k::webhook::package::webrick_version`.
 
 ### Webhook Slack notifications
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -157,8 +157,12 @@ class r10k::params
   $webhook_configfile_mode       = '0644'
   $webhook_ignore_environments   = []
   $webhook_mco_arguments         = undef
-  $webhook_sinatra_version       = '~> 1.0'      # Sinatra 2 requires rack 2 which in turn requires ruby 2.2. Puppet 4 AIO ships with ruby 2.1
-  $webhook_webrick_version       = '1.3.1'       # Webrick 1.4 requires ruby >= 2.3
+  if $facts['pe_server_version'] == '2016.4.2' {
+    $webhook_sinatra_version       = '~> 1.0'
+  } else {
+    $webhook_sinatra_version       = 'installed'
+  }
+  $webhook_webrick_version       = 'installed'
   $webhook_generate_types        = false
 
   # Service Settings for SystemD in EL7

--- a/manifests/webhook/package.pp
+++ b/manifests/webhook/package.pp
@@ -13,6 +13,7 @@ class r10k::webhook::package (
       notify   => Service['webhook'],
     }
   }
+
   if (! $is_pe_server) {
     if !defined(Package['webrick']) {
       package { 'webrick':

--- a/spec/classes/webhook/package_spec.rb
+++ b/spec/classes/webhook/package_spec.rb
@@ -40,8 +40,8 @@ describe 'r10k::webhook::package', type: :class do
           )
         end
 
-        it { is_expected.to contain_package('sinatra').with(ensure: '~> 1.0') }
-        it { is_expected.to contain_package('webrick').with(ensure: '1.3.1') }
+        it { is_expected.to contain_package('sinatra').with(ensure: 'installed') }
+        it { is_expected.to contain_package('webrick').with(ensure: 'installed') }
         it { is_expected.to contain_package('json').with(ensure: 'installed') }
       end
     end


### PR DESCRIPTION
Since webrick has been part of the ruby standard library for a while, its version doesn't need to be specified anymore.

The sinatra gem comes with Puppet, so its version also doesn't need to be specified.

Fixes  #471.
