### PR TITLE
Use latest gentoo/portage release

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,4 @@ fixtures:
     inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
     vcsrepo: "https://github.com/puppetlabs/puppetlabs-vcsrepo.git"
     git:     "https://github.com/puppetlabs/puppetlabs-git.git"
-    portage:
-      repo: "https://github.com/gentoo/puppet-portage.git"
-      ref: "2.3.0"
+    portage: "https://github.com/gentoo/puppet-portage.git"

--- a/metadata.json
+++ b/metadata.json
@@ -73,7 +73,7 @@
     },
     {
       "name": "gentoo/portage",
-      "version_requirement": "2.3.0"
+      "version_requirement": ">= 2.4.5 < 3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
This release was previously pinned because of bugs in 2.4.0. The next
release, 2.4.5, claims to have fixed these issues. Setting the lower
bound to 2.4.5 as to not include the known bad version of 2.4.0.
