### PR TITLE
Remove support for providers yum, zypper

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,6 @@ The supported installation modes for this module
 * bundle
 * puppet_gem
 * gem
-* zypper
 
 ##### `install_options`
 Options to pass to the `provider` declaration

--- a/README.md
+++ b/README.md
@@ -778,7 +778,6 @@ The name of the package to be installed via the provider
 ##### `provider`
 The supported installation modes for this module
 
-* yum
 * bundle
 * puppet_gem
 * gem

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,7 @@ class r10k::install (
     'bundle': {
       include r10k::install::bundle
     }
-    'puppet_gem', 'gem', 'openbsd', 'zypper': {
+    'puppet_gem', 'gem', 'openbsd': {
       if $provider == 'gem' {
         class { 'r10k::install::gem':
           manage_ruby_dependency => $manage_ruby_dependency,
@@ -62,6 +62,6 @@ class r10k::install (
       }
 
     }
-    default: { fail("${module_name}: ${provider} is not supported. Valid values are: 'gem', 'puppet_gem', 'bundle', 'openbsd', 'zypper'") }
+    default: { fail("${module_name}: ${provider} is not supported. Valid values are: 'gem', 'puppet_gem', 'bundle', 'openbsd'") }
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,7 +19,6 @@ class r10k::install (
                       $real_package_name = 'ruby22-r10k'
                     }
                   }
-      'yum':     { $real_package_name = 'rubygem-r10k' }
       default:   { $real_package_name = 'r10k' }
     }
   } else {
@@ -30,7 +29,7 @@ class r10k::install (
     'bundle': {
       include r10k::install::bundle
     }
-    'puppet_gem', 'gem', 'openbsd', 'yum', 'zypper': {
+    'puppet_gem', 'gem', 'openbsd', 'zypper': {
       if $provider == 'gem' {
         class { 'r10k::install::gem':
           manage_ruby_dependency => $manage_ruby_dependency,
@@ -63,6 +62,6 @@ class r10k::install (
       }
 
     }
-    default: { fail("${module_name}: ${provider} is not supported. Valid values are: 'gem', 'puppet_gem', 'bundle', 'openbsd', 'yum', 'zypper'") }
+    default: { fail("${module_name}: ${provider} is not supported. Valid values are: 'gem', 'puppet_gem', 'bundle', 'openbsd', 'zypper'") }
   }
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -149,23 +149,6 @@ describe 'r10k::install' do
         it { is_expected.to contain_class('r10k::install::bundle') }
         it { is_expected.not_to contain_package('r10k') }
       end
-
-      context 'with yum provider' do
-        let :params do
-          {
-            install_options:        '',
-            keywords:               '',
-            manage_ruby_dependency: 'declare',
-            package_name:           'rubygem-r10k',
-            provider:               'yum',
-            version:                'latest',
-            puppet_master:          true
-          }
-        end
-
-        it { is_expected.not_to contain_class('git') }
-        it { is_expected.to contain_package('rubygem-r10k') }
-      end
     end
   end
 

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -151,28 +151,4 @@ describe 'r10k::install' do
       end
     end
   end
-
-  context 'with zypper provider' do
-    let :params do
-      {
-        install_options:        '',
-        keywords:               '',
-        manage_ruby_dependency: 'declare',
-        package_name:           'r10k',
-        provider:               'zypper',
-        version:                'latest',
-        puppet_master:          true
-      }
-    end
-    let :facts do
-      {
-        osfamily:               'Suse',
-        operatingsystemrelease: '11.3',
-        puppetversion:          Puppet.version
-      }
-    end
-
-    it { is_expected.not_to contain_class('git') }
-    it { is_expected.to contain_package('r10k') }
-  end
 end


### PR DESCRIPTION
This pull request removes support for providers ```yum``` and ```zypper```. We also might want to remove support for OpenBSD and remove the ```package``` resource, since this was introduced for Puppet Enterprise which has ```r10k``` already installed.

This will fix issue #449.