### PR TITLE
Allow uppercase characters in environment names

### DIFF
--- a/tasks/deploy.json
+++ b/tasks/deploy.json
@@ -4,11 +4,11 @@
   "parameters": {
     "environment": {
       "description": "The environment to deploy.",
-      "type": "Optional[Pattern[/\\A[a-z0-9_]+\\Z/]]"
+      "type": "Optional[Pattern[/\\A[a-zA-Z0-9_]+\\Z/]]"
     },
     "environments": {
       "description": "A comma separated list of environments to deploy. Takes precedence over `environment`.",
-      "type": "Optional[Pattern[/\\A[a-z0-9_,]+\\Z/]]"
+      "type": "Optional[Pattern[/\\A[a-zA-Z0-9_,]+\\Z/]]"
     },
     "module": {
       "description": "A module to deploy across all environments.",


### PR DESCRIPTION
#### Pull Request (PR) description
Previously the `r10k::deploy` task would limit the `environment` name to a regex that only matched lowercase characters. However, `r10k` does allow for environment names to contain uppercase characters because `r10k deploy environment -pv ABC123_test` works correctly. 

This PR modifies the regex for the  `r10k::deploy` task to allow for uppercase characters in environment names.

Question: should we also allow for uppercase characters in module names?

#### This Pull Request (PR) fixes the following issues
n/a
