### PR TITLE
Wrap slack_icon with colons

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -300,7 +300,7 @@ class Server < Sinatra::Base
       end
 
       if $config['slack_icon']
-        slack_icon = $config['slack_icon']
+        slack_icon = ":#{$config['slack_icon']}:"
       else
         slack_icon = ':ocean:'
       end


### PR DESCRIPTION
#### Pull Request (PR) description  
The configuration file for the webhook config writes values that
begin with colons (:) as symbols rather than strings, to allow
for calculated values.

Since slack emoji names follow the pattern of `:name:`, they are
written as symbols instead of strings, and the resulting config
file breaks the webhook service.

This change simply requires slack icons to be entered without the
wrapping colons, and adds them back just before sending to Slack.

Where previously the ocean icon would be written as `:ocean:` in
the webhook_slack_icon parameter, now it would be written as `ocean`.

#### This Pull Request (PR) fixes the following issues  
n/a