### PR TITLE
Add slack_icon docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,9 +605,12 @@ class { 'r10k::webhook::config':
   slack_webhook   => 'http://slack.webhook/webhook', # mandatory for usage
   slack_channel   => '#channel', # defaults to #default
   slack_username  => 'r10k', # the username to use
-  slack_proxy_url => 'http://proxy.example.com:3128' # Optional.  Defaults to undef.
+  slack_proxy_url => 'http://proxy.example.com:3128', # Optional.  Defaults to undef.
+  slack_icon      => 'unicorn_face' # Optional. Defaults to 'ocean'
 }
 ```
+
+Note that slack icon names should omit the opening and closing colons (`:`).
 
 ### Webhook Rocket.Chat notifications
 

--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ class { 'r10k::webhook::config':
   slack_channel   => '#channel', # defaults to #default
   slack_username  => 'r10k', # the username to use
   slack_proxy_url => 'http://proxy.example.com:3128', # Optional.  Defaults to undef.
-  slack_icon      => 'unicorn_face' # Optional. Defaults to 'ocean'
+  slack_icon      => 'unicorn_face' # Optional. Defaults to undef.
 }
 ```
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,7 +151,7 @@ class r10k::params
   $webhook_slack_channel         = undef
   $webhook_slack_username        = undef
   $webhook_slack_proxy_url       = undef
-  $webhook_slack_icon            = 'ocean'
+  $webhook_slack_icon            = undef
   $webhook_rocketchat_webhook    = undef
   $webhook_rocketchat_channel    = undef
   $webhook_rocketchat_username   = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,7 +151,7 @@ class r10k::params
   $webhook_slack_channel         = undef
   $webhook_slack_username        = undef
   $webhook_slack_proxy_url       = undef
-  $webhook_slack_icon            = undef
+  $webhook_slack_icon            = 'ocean'
   $webhook_rocketchat_webhook    = undef
   $webhook_rocketchat_channel    = undef
   $webhook_rocketchat_username   = undef


### PR DESCRIPTION
#### Pull Request (PR) description
This PR updates the README with information about the `slack_icon` configuration option for the webhook. 

#### This Pull Request (PR) fixes the following issues
n/a.