### PR TITLE
Trim "full_name" when module name has no dash

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -115,10 +115,7 @@ class Server < Sinatra::Base
 
     if data['repository'].has_key?('full_name')
       # handle BitBucket webhook...
-      module_name = ( data['repository']['full_name'] ).sub(/^.*\/.*-/, '')
-      # if the module name part does not contain a dash in the 'full_name'
-      # (i.e., the previous trimming did not work)
-      module_name = ( data['repository']['full_name'] ).sub(/^.*\//, '')
+      module_name = ( data['repository']['full_name'] ).sub(/^.*\/(.*-)?/, '')
     else
       module_name = ( data['repository']['name'] ).sub(/^.*-/, '')
     end

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -116,6 +116,9 @@ class Server < Sinatra::Base
     if data['repository'].has_key?('full_name')
       # handle BitBucket webhook...
       module_name = ( data['repository']['full_name'] ).sub(/^.*\/.*-/, '')
+      # if the module name part does not contain a dash in the 'full_name'
+      # (i.e., the previous trimming did not work)
+      module_name = ( data['repository']['full_name'] ).sub(/^.*\//, '')
     else
       module_name = ( data['repository']['name'] ).sub(/^.*-/, '')
     end


### PR DESCRIPTION
#### Pull Request (PR) description
If the module name has no dash (i.e., data['repository']['full_name'] = 'owner/module_name' ), then previous trimming will not work.
In such case we need trim 'owner/' part in the 'full_name' variable.

#### This Pull Request (PR) fixes the following issues
Fixes #496