### PR TITLE
r10k webhook logfiles should not be executable

### DIFF
--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -20,7 +20,7 @@ class r10k::webhook(
     ensure => $ensure,
     owner  => $root_user,
     group  => $root_group,
-    mode   => '0755',
+    mode   => '0644',
   }
 
   # Rewrite the params to style guide in lieu of
@@ -49,17 +49,15 @@ class r10k::webhook(
     ensure => $ensure_file,
     owner  => $user,
     group  => $group,
-    mode   => '0644',
     before => File['webhook_bin'],
   }
 
   file { '/var/log/webhook':
-    ensure  => $ensure_directory,
-    owner   => $user,
-    group   => $group,
-    recurse => $ensure,
-    force   => $ensure,
-    before  => File['webhook_bin'],
+    ensure => $ensure_directory,
+    owner  => $user,
+    group  => $group,
+    force  => $ensure,
+    before => File['webhook_bin'],
   }
 
   file { '/var/run/webhook':
@@ -81,6 +79,7 @@ class r10k::webhook(
     ensure  => $ensure_file,
     content => template($bin_template),
     path    => '/usr/local/bin/webhook',
+    mode    => '0755',
     notify  => Service['webhook'],
   }
 


### PR DESCRIPTION
fixes #499 

webhook manifest sets the webhook logdirectory to 0755 using recurse.
when using logrotation the logrotate config file should be able to set individual permissions on rotated logfiles.

changing file resource default from 0644 to 0755 as puppet internally will set directories to 0755 by itself: https://github.com/puppetlabs/puppet/blob/master/lib/puppet/type/file/mode.rb#L102

removing recurse true to allow logrotate to set individual permissions.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
