### PR TITLE
Add additional curl example for environment prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,6 +697,16 @@ curl -d '
   }' http://puppet-master.example:8088/payload
 ```
 
+If you are utilizing environment prefixes, you'll need to specify the full environment title (including the prefix) in the 'ref' parameter:
+
+```bash
+curl -d '
+  {
+    "repository": {"name": "bar", "owner": {"login": "foo"}},
+    "ref": "bar_production"
+  }' http://puppet-master.example:8088/payload
+```
+
 ### Troubleshooting
 
 If you're not sure whether your webhook setup works:


### PR DESCRIPTION
#### Pull Request (PR) description
The current documentation for [triggering the webhook via curl](https://github.com/voxpupuli/puppet-r10k/blob/master/README.md#triggering-the-webhook-from-curl) only specifies an example for non-prefixed environments.  With the current data structure format, it's unclear whether the full environment name needs to be specified in the 'ref' parameter.  This PR implements clear documentation, noting that the full environment name is required.

#### This Pull Request (PR) contributes a partial fix for the following issues
#422

