### PR TITLE
Fixes: Travis CI tests, webhook IPv4/IPv6, webhook intermediate certificates

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -131,7 +131,7 @@ class r10k::params
   $mc_git_ssl_no_verify = 0
 
   # Webhook configuration information
-  $webhook_bind_address          = '0.0.0.0'
+  $webhook_bind_address          = '*'
   $webhook_port                  = '8088'
   $webhook_access_logfile        = '/var/log/webhook/access.log'
   $webhook_client_cfg            = '/var/lib/peadmin/.mcollective'

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -30,7 +30,7 @@ describe 'r10k::webhook::config', type: :class do
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 certname: "peadmin"
 certpath: "/var/lib/peadmin/.mcollective.d"
 client_cfg: "/var/lib/peadmin/.mcollective"
@@ -83,7 +83,7 @@ user: "peadmin"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 certname: "peadmin"
 certpath: "/var/lib/peadmin/.mcollective.d"
 client_cfg: "/var/lib/peadmin/.mcollective"
@@ -147,7 +147,7 @@ user: "peadmin"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -192,7 +192,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -236,7 +236,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -281,7 +281,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 bitbucket_secret: "secret"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
@@ -326,7 +326,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -371,7 +371,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -458,7 +458,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -57,10 +57,15 @@ opts = {
   :StartCallback  => Proc.new { File.open(PIDFILE, 'w') {|f| f.write Process.pid } },
 }
 if $config['enable_ssl'] then
+  CERT_PATTERN = /-----BEGIN .*?-----END .*?-----/m
+  certs = File.open("#{$config['public_key_path']}").read.scan(CERT_PATTERN)
   opts[:SSLVerifyClient] = OpenSSL::SSL::VERIFY_NONE
-  opts[:SSLCertificate]  = OpenSSL::X509::Certificate.new(File.open("#{$config['public_key_path']}").read)
+  opts[:SSLCertificate]  = OpenSSL::X509::Certificate.new(certs.shift)
   opts[:SSLPrivateKey]   = OpenSSL::PKey::RSA.new(File.open("#{$config['private_key_path']}").read)
   opts[:SSLCertName]     = [ [ "CN",WEBrick::Utils::getservername ] ]
+  if ! certs.empty? then
+    opts[:SSLExtraChainCert] = certs.map { |x| OpenSSL::X509::Certificate.new(x) }
+  end
 end
 
 if $config['use_mcollective'] then


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request fixes three issues:
- the currently failing Travis CI tests (#509)
- support for the webhook to listen on both IPv4 and IPv6 by default (#490)
- support for the webhook to use intermediate TLS certificates (#510)

These three issues are unrelated.  They are submitted as a single pull request only because the first commit in this series is required to fix the Travis CI tests, without which it is impossible to get a Travis CI pass for the other commits in the series.

#### This Pull Request (PR) fixes the following issues
Fixes #509 
Fixes #490 
Fixes #510
