### PR TITLE
fix webhook generate type functionailty for non-root user

### DIFF
--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -49,7 +49,7 @@ class r10k::webhook(
     ensure => $ensure_file,
     owner  => $user,
     group  => $group,
-    before => File['webhook_bin'],
+    before => Service['webhook'],
   }
 
   file { '/var/log/webhook':
@@ -57,14 +57,14 @@ class r10k::webhook(
     owner  => $user,
     group  => $group,
     force  => $ensure,
-    before => File['webhook_bin'],
+    before => Service['webhook'],
   }
 
   file { '/var/run/webhook':
     ensure => $ensure_directory,
     owner  => $user,
     group  => $group,
-    before => File['webhook_init_script'],
+    before => Service['webhook'],
   }
 
   file { 'webhook_init_script':
@@ -72,7 +72,7 @@ class r10k::webhook(
     content => template("r10k/${service_template}"),
     path    => $service_file,
     mode    => $service_file_mode,
-    before  => File['webhook_bin'],
+    notify  => Service['webhook'],
   }
 
   file { 'webhook_bin':

--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -273,7 +273,16 @@ class Server < Sinatra::Base
 
     def generate_types(environment)
       begin
-        command = "#{$command_prefix} /opt/puppetlabs/bin/puppet generate types --environment #{environment.gsub(/\W/, '_')}"
+<% if @user != 'root' -%>
+<%# explicitly set working directories for non-root accounts -%>
+<% @generate_suffix=' --confdir ' + scope.lookupvar('settings::confdir') +
+  ' --codedir ' + scope.lookupvar('settings::codedir') +
+  ' --vardir  ' + scope.lookupvar('settings::vardir')
+-%>
+<% else -%>
+<% @generate_suffix='' -%>
+<% end -%>
+        command = "#{$command_prefix} /opt/puppetlabs/bin/puppet generate types --environment #{environment.gsub(/\W/, '_')}<%= @generate_suffix %>"
 
         message = run_command(command)
         $logger.info("message: #{message} environment: #{environment}")


### PR DESCRIPTION
#### Pull Request (PR) description
if webhook is running under unprivileged account it creates
.resource_types in it's home directory, instead of code directory
explicitly pass parameters to point to configured code location

#### This Pull Request (PR) fixes the following issues
Fixes #412
