### PR TITLE
Change webhook systemd service type to `simple`

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -138,7 +138,6 @@ class r10k::params
   $webhook_default_branch        = 'production'
   $webhook_use_mco_ruby          = false
   $webhook_protected             = true
-  $webhook_background            = true
   $webhook_github_secret         = undef
   $webhook_bitbucket_secret      = undef
   $webhook_discovery_timeout     = 10
@@ -180,13 +179,16 @@ class r10k::params
     $webhook_service_file      = '/etc/init.d/webhook'
     $webhook_service_template  = 'webhook.init.gentoo.erb'
     $webhook_service_file_mode = '0755'
+    $webhook_background        = true
   } elsif $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] < '7' {
     $webhook_service_file      = '/etc/init.d/webhook'
     $webhook_service_template  = 'webhook.init.erb'
     $webhook_service_file_mode = '0755'
+    $webhook_background        = true
   } else {
     $webhook_service_file      = '/etc/systemd/system/webhook.service'
     $webhook_service_template  = 'webhook.service.erb'
     $webhook_service_file_mode = '0644'
+    $webhook_background        = false
   }
 }

--- a/templates/webhook.service.erb
+++ b/templates/webhook.service.erb
@@ -3,18 +3,15 @@ Description=R10K Webhook Service
 After=syslog.target network.target
 
 [Service]
-Type=forking
+Type=simple
 EnvironmentFile=-/etc/sysconfig/webhook
 RuntimeDirectory=webhook
 User=<%= @user %>
-PIDFile=/var/run/webhook/webhook.pid
 TimeoutStartSec=90
 TimeoutStopSec=30
 RestartSec=10000
 
 ExecStart=/usr/local/bin/webhook
-
-KillMode=process
 
 StandardOutput=syslog
 


### PR DESCRIPTION
This is the preferred option according to the systemd project.

> It is generally recommended to use Type=simple for long-running services whenever possible, as it is the simplest and fastest option.

Fixes #509