### PR TITLE
Fix webhook deployment on IPv6 machines

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -131,7 +131,7 @@ class r10k::params
   $mc_git_ssl_no_verify = 0
 
   # Webhook configuration information
-  $webhook_bind_address          = '0.0.0.0'
+  $webhook_bind_address          = '*'
   $webhook_port                  = '8088'
   $webhook_access_logfile        = '/var/log/webhook/access.log'
   $webhook_client_cfg            = '/var/lib/peadmin/.mcollective'

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -30,7 +30,7 @@ describe 'r10k::webhook::config', type: :class do
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 certname: "peadmin"
 certpath: "/var/lib/peadmin/.mcollective.d"
 client_cfg: "/var/lib/peadmin/.mcollective"
@@ -83,7 +83,7 @@ user: "peadmin"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 certname: "peadmin"
 certpath: "/var/lib/peadmin/.mcollective.d"
 client_cfg: "/var/lib/peadmin/.mcollective"
@@ -147,7 +147,7 @@ user: "peadmin"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -192,7 +192,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -236,7 +236,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -281,7 +281,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 bitbucket_secret: "secret"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
@@ -326,7 +326,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -371,7 +371,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"
@@ -458,7 +458,7 @@ user: "puppet"
         content = '---
 access_logfile: "/var/log/webhook/access.log"
 allow_uppercase: true
-bind_address: "0.0.0.0"
+bind_address: "*"
 client_cfg: "/var/lib/peadmin/.mcollective"
 client_timeout: "120"
 command_prefix: "umask 0022;"


### PR DESCRIPTION
#### Pull Request (PR) description

Split from #511 

The default bind_address is currently "0.0.0.0", which causes the
webhook to listen only for IPv4 connections.  Change the default to
"*" so that the webhook will listen for both IPv4 and IPv6
connections.

#### This Pull Request (PR) fixes the following issues

Fixes #490
