### PR TITLE
Use full certificate chain for webhook

### DIFF
--- a/templates/webhook.bin.erb
+++ b/templates/webhook.bin.erb
@@ -57,10 +57,15 @@ opts = {
   :StartCallback  => Proc.new { File.open(PIDFILE, 'w') {|f| f.write Process.pid } },
 }
 if $config['enable_ssl'] then
+  CERT_PATTERN = /-----BEGIN.+?CERTIFICATE-----.+?-----END.+?CERTIFICATE-----/m
+  certs = File.open("#{$config['public_key_path']}").read.scan(CERT_PATTERN)
   opts[:SSLVerifyClient] = OpenSSL::SSL::VERIFY_NONE
-  opts[:SSLCertificate]  = OpenSSL::X509::Certificate.new(File.open("#{$config['public_key_path']}").read)
+  opts[:SSLCertificate]  = OpenSSL::X509::Certificate.new(certs.shift)
   opts[:SSLPrivateKey]   = OpenSSL::PKey::RSA.new(File.open("#{$config['private_key_path']}").read)
   opts[:SSLCertName]     = [ [ "CN",WEBrick::Utils::getservername ] ]
+  if ! certs.empty? then
+    opts[:SSLExtraChainCert] = certs.map { |x| OpenSSL::X509::Certificate.new(x) }
+  end
 end
 
 if $config['use_mcollective'] then


### PR DESCRIPTION
#### Pull Request (PR) description

Split from #511 

The webhook service is currently limited to using a certificate
directly issued by a trusted CA; it will silently ignore any
intermediate certificates that are present in the certificate file.

The currently released versions of the Ruby OpenSSL libraries do not
provide any clean way to load a certificate chain from a file.  We
therefore split the file using the BEGIN/END markers as per RFC 7468,
and construct the certificate chain directly.

No tests are extended to cover this enhancement, since there is no
existing test coverage for the use of HTTPS certificates by the
webhook.  All current tests use plain HTTP via http://localhost:8088.

#### This Pull Request (PR) fixes the following issues

Fixes #510
