### PR TITLE
Remove `anchor` resource from `r10k::install::gem`

### DIFF
--- a/manifests/install/gem.pp
+++ b/manifests/install/gem.pp
@@ -4,23 +4,19 @@ class r10k::install::gem (
   $version,
 ) {
   require git
-  anchor{'r10k::ruby_done':}
+
   case $manage_ruby_dependency {
     'include': {
       include ruby
-      include ruby::dev
-      Class['::ruby']
-      -> Class['ruby::dev']
-      -> Anchor['r10k::ruby_done']
+      require ruby::dev
+      Class['ruby'] -> Class['ruby::dev']
     }
     'declare': {
       class { 'ruby':
         rubygems_update => false,
       }
-      include ruby::dev
-      Class['::ruby']
-      -> Class['::ruby::dev']
-      -> Anchor['r10k::ruby_done']
+      require ruby::dev
+      Class['ruby'] -> Class['ruby::dev']
     }
     default: {
       #This catches the 'ignore' case, and satisfies the 'default' requirement


### PR DESCRIPTION
I've refactored the class to not use the anchor resource.
Since
https://github.com/voxpupuli/puppet-r10k/commit/78283bd8c1995f54398ec30478fb0adfc6ea59ec#diff-41c34a669409f2dbaa4211d5f642a003L40
it is not being referred to from any other class.

If someone needs to create a similar relationship, they can use
`Class['r10k::install::gem']` instead.