### PR TITLE
fix: avoid using deprecated gem options

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -48,7 +48,7 @@ class r10k::install (
       # converts an empty array to semi-standard gem options
       # This was previously undef but that caused strict var issues
       if $provider in ['puppet_gem', 'gem'] and $install_options == [] {
-        $provider_install_options = ['--no-ri', '--no-rdoc']
+        $provider_install_options = ['--no-document']
       } else {
         $provider_install_options = $install_options
       }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -48,7 +48,7 @@ describe 'r10k::install' do
           is_expected.to contain_package('r10k').with(
             ensure:          version,
             provider:        'gem',
-            install_options: ['--no-ri', '--no-rdoc']
+            install_options: ['--no-document']
           )
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description

Options `--no-ri` and `--no-rdoc` have been deprecated in Ruby 2.6.0 and replaced by `--no-document`.

#### This Pull Request (PR) fixes the following issues

Fixes #544.