### PR TITLE
Add support for FreeBSD package provider

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,7 @@ class r10k::install (
     'bundle': {
       include r10k::install::bundle
     }
-    'puppet_gem', 'gem', 'openbsd': {
+    'puppet_gem', 'gem', 'openbsd', 'pkgng': {
       if $provider == 'gem' {
         class { 'r10k::install::gem':
           manage_ruby_dependency => $manage_ruby_dependency,


### PR DESCRIPTION
Without this change, the FreeBSD package provider 'pkgng' is not a valid option.  Including this change allows this module to manage the r10k package from ports on FreeBSD systems.