### PR TITLE
webhook config: allow access_log to be nil by using special value "stderr"

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -118,7 +118,6 @@ class r10k::params {
   # Webhook configuration information
   $webhook_bind_address          = '*'
   $webhook_port                  = '8088'
-  $webhook_access_logfile        = '/var/log/webhook/access.log'
   $webhook_client_cfg            = '/var/lib/peadmin/.mcollective'
   $webhook_default_branch        = 'production'
   $webhook_use_mco_ruby          = false

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -14,7 +14,7 @@ class r10k::webhook::config (
   $pass                                 = $r10k::params::webhook_pass,
   $bind_address                         = $r10k::params::webhook_bind_address,
   $port                                 = $r10k::params::webhook_port,
-  $access_logfile                       = $r10k::params::webhook_access_logfile,
+  Variant[Stdlib::Absolutepath, Enum['stderr']] $access_logfile = '/var/log/webhook/access.log',
   $client_cfg                           = $r10k::params::webhook_client_cfg,
   $default_branch                       = $r10k::params::webhook_default_branch,
   $use_mco_ruby                         = $r10k::params::webhook_use_mco_ruby,

--- a/spec/classes/webhook/config_spec.rb
+++ b/spec/classes/webhook/config_spec.rb
@@ -306,6 +306,49 @@ user: "puppet"
         it { is_expected.to contain_file('webhook.yaml').with_content(content) }
       end
 
+      context 'FOSS with access_logfile = stderr' do
+        let :params do
+          {
+            access_logfile: 'stderr',
+          }
+        end
+
+        it do
+          is_expected.to contain_file('webhook.yaml').with(
+            path:   '/etc/webhook.yaml',
+            ensure: 'file',
+            owner:  'root',
+            group:  'root',
+            mode:   '0644',
+            notify: 'Service[webhook]'
+          )
+        end
+        content = '---
+allow_uppercase: true
+bind_address: "*"
+client_cfg: "/var/lib/peadmin/.mcollective"
+client_timeout: "120"
+command_prefix: "umask 0022;"
+default_branch: "production"
+discovery_timeout: "10"
+enable_mutex_lock: false
+enable_ssl: true
+generate_types: false
+ignore_environments: []
+pass: "puppet"
+port: "8088"
+prefix: false
+prefix_command: "/bin/echo example"
+protected: true
+r10k_deploy_arguments: "-pv"
+server_software: "WebHook"
+use_mco_ruby: false
+use_mcollective: true
+user: "puppet"
+'
+        it { is_expected.to contain_file('webhook.yaml').with_content(content) }
+      end
+
       context 'FOSS with BitBucket server secret enabled' do
         let :params do
           {

--- a/templates/webhook.yaml.erb
+++ b/templates/webhook.yaml.erb
@@ -1,6 +1,8 @@
 ---
 <% @webhook_hash.sort.each do |key,value| -%>
-<% if value != :undef and ! value.nil? -%>
+<%- if key == 'access_logfile' and value == 'stderr' -%>
+<%# Don't output access_logfile if its value is stderr -%>
+<% elsif value != :undef and ! value.nil? -%>
 <%
   value = case value
   when TrueClass, FalseClass


### PR DESCRIPTION
This is kind of an unfortunate hack, but submitting it here in case it's useful to someone else.

WEBrick allows for logging to stderr if access_logfile is nil, but with the default for the class parameter set to `/var/log/webhook/access.log`, it wasn't possible to set access_logfile to nil (undef in Puppet). This commit makes that possible by using the special string `stderr`, while also maintaining backward compatibility.

Having webhook logging to stderr is useful if you want systemd journal to handle logging instead of having a separate log file.