### PR TITLE
make puppetlabs/ruby optional

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@ class r10k::params {
   $package_name           = ''
   $version                = 'installed'
   $manage_modulepath      = false
-  $manage_ruby_dependency = 'declare'
+  $manage_ruby_dependency = 'ignore'
 
   $provider = $facts['os']['name'] ? {
     'Archlinux' => 'gem',

--- a/metadata.json
+++ b/metadata.json
@@ -65,7 +65,7 @@
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">= 1.3.1 < 4.0.0"
+      "version_requirement": ">= 1.3.1 < 5.0.0"
     },
     {
       "name": "choria/mcollective",

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.19.0 < 7.0.0"
+      "version_requirement": ">= 4.19.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/ruby",

--- a/metadata.json
+++ b/metadata.json
@@ -61,7 +61,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.4.1 < 5.0.0"
+      "version_requirement": ">= 1.4.1 < 6.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",

--- a/metadata.json
+++ b/metadata.json
@@ -56,10 +56,6 @@
       "version_requirement": ">= 4.19.0 < 8.0.0"
     },
     {
-      "name": "puppetlabs/ruby",
-      "version_requirement": ">= 0.6.0 < 2.0.0"
-    },
-    {
       "name": "puppetlabs/inifile",
       "version_requirement": ">= 1.4.1 < 6.0.0"
     },


### PR DESCRIPTION
the puppetlabs/ruby module is deprecated and most people don't use it
anyways. This PR makes the dependency optional.