### PR TITLE
Remove explicit StandardOutput from webhook.service

### DIFF
--- a/templates/webhook.service.erb
+++ b/templates/webhook.service.erb
@@ -10,10 +10,7 @@ User=<%= @user %>
 TimeoutStartSec=90
 TimeoutStopSec=30
 RestartSec=10000
-
 ExecStart=/usr/local/bin/webhook
-
-StandardOutput=syslog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd 247 complains that this setting is obsolete:

`systemd[1]: /etc/systemd/system/webhook.service:16: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.`

The default for standard output is "journal" which means the same
thing as the old "syslog" setting.