### PR TITLE
Allow defining mcollective policies on the r10k agent

### DIFF
--- a/manifests/install/bundle.pp
+++ b/manifests/install/bundle.pp
@@ -21,6 +21,6 @@ class r10k::install::bundle (
     cwd     => '/tmp/r10k',
     require => [Package["${module_name}-bundle"], Vcsrepo["${module_name}-r10k-github"]],
     unless  => 'bundle list | grep -q " r10k "',
-    path    => $::path,
+    path    => $::facts['path'],
   }
 }

--- a/manifests/install/puppet_gem.pp
+++ b/manifests/install/puppet_gem.pp
@@ -1,6 +1,6 @@
 # This class links the r10k binary for Puppet FOSS 4.2 and up
 class r10k::install::puppet_gem {
-  if versioncmp("${::puppetversion}", '4.2.0') >= 0 { #lint:ignore:only_variable_string
+  if versioncmp("${::facts['puppetversion']}", '4.2.0') >= 0 { #lint:ignore:only_variable_string
     file { '/usr/bin/r10k':
       ensure  => link,
       target  => '/opt/puppetlabs/puppet/bin/r10k',

--- a/manifests/mcollective.pp
+++ b/manifests/mcollective.pp
@@ -4,6 +4,7 @@ class r10k::mcollective (
   $server            = true,
   $client            = true,
   $http_proxy        = '',
+  $policies          = [],
 ) inherits r10k::params {
   include mcollective
   mcollective::module_plugin { 'mcollective_agent_r10k':
@@ -24,5 +25,6 @@ class r10k::mcollective (
     client_files  => [
       'application/r10k.rb',
     ],
+    policies      => $policies,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class r10k::params {
   $forge_settings            = {}
   $deploy_settings           = {}
   # Git configuration
-  $git_server = $::settings::ca_server
+  $git_server = $::settings::ca_server #lint:ignore:top_scope_facts
   $repo_path  = '/var/repos'
   $remote     = "ssh://${git_server}${repo_path}/modules.git"
 


### PR DESCRIPTION
#### Pull Request (PR) description

Allows defining per-agent policies for the r10k mcollective agent running under choria/mcollective. Without this, it is only possible to use site policies (used on all types), or the default policy, and it's not possible to defined a fine-grained policy for a choria user to use the r10k agent (e.g. a CI/CD system).