### PR TITLE
Fix mco r10k deploy command in docs to match actual behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ mco r10k synchronize
 You can sync an individual environment using:
 
 ```shell
-mco r10k deploy environment <environment>
+mco r10k deploy <environment>
 ```
 Note: This implies `-p`
 


### PR DESCRIPTION
#### Pull Request (PR) description

The `mco r10k` application takes the next arg following the `deploy`
action as the environment name to be updated. The example command
in the README prefixes the environment name with the `environment`
keyword, which causes r10k to be invoked as

```bash
r10k deploy environment environment -p
```

instead of the expected environment name. Since the `environment`
environment likely does not exist, this renders the `mco r10k deploy`
command a noop.

#### This Pull Request (PR) fixes the following issues

Fixes #573
