### PR TITLE
Arch Linux: Disable acceptance tests for webhook

### DIFF
--- a/spec/acceptance/basic_webhook_spec.rb
+++ b/spec/acceptance/basic_webhook_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'System Ruby with No SSL, Not protected, No mcollective' do
+describe 'System Ruby with No SSL, Not protected, No mcollective', unless: default[:platform] =~ %r{archlinux} do
   context 'with basics parameters' do
     hosts_as('agent').each do |agent|
       it 'applies with no errors and idempotently' do

--- a/spec/acceptance/gitlab_token_webhook_spec.rb
+++ b/spec/acceptance/gitlab_token_webhook_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper_acceptance'
 require 'openssl'
 
-describe 'GitLab Secret Token Enabled, System Ruby with No SSL, Not protected, No mcollective' do
+describe 'GitLab Secret Token Enabled, System Ruby with No SSL, Not protected, No mcollective', unless: default[:platform] =~ %r{archlinux} do
   context 'default parameters' do
     pp = %(
       class { 'r10k':

--- a/spec/acceptance/prefix_webhook_spec.rb
+++ b/spec/acceptance/prefix_webhook_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'Prefix Enabled,System Ruby with No SSL, Not protected, No mcollective' do
+describe 'Prefix Enabled,System Ruby with No SSL, Not protected, No mcollective', unless: default[:platform] =~ %r{archlinux} do
   context 'default parameters' do
     pp = %(
       file {'/usr/local/bin/prefix_command.rb':

--- a/spec/acceptance/signature_webhook_bitbucket_spec.rb
+++ b/spec/acceptance/signature_webhook_bitbucket_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper_acceptance'
 require 'openssl'
 
-describe 'BitBucket Secret Enabled, System Ruby with No SSL, Not protected, No mcollective' do
+describe 'BitBucket Secret Enabled, System Ruby with No SSL, Not protected, No mcollective', unless: default[:platform] =~ %r{archlinux} do
   context 'default parameters' do
     pp = %(
       class { 'r10k':

--- a/spec/acceptance/signature_webhook_github_spec.rb
+++ b/spec/acceptance/signature_webhook_github_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper_acceptance'
 require 'openssl'
 
-describe 'GitHub Secret Enabled, System Ruby with No SSL, Not protected, No mcollective' do
+describe 'GitHub Secret Enabled, System Ruby with No SSL, Not protected, No mcollective', unless: default[:platform] =~ %r{archlinux} do
   context 'default parameters' do
     pp = %(
       class { 'r10k':


### PR DESCRIPTION
This module currently doesn't support the webhook on Arch Linux, so we
do not neet to run the tests on it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
