### PR TITLE
Fix webhook setup when using older Puppet/Ruby

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -124,7 +124,7 @@ If you have Ruby 2.x or want a specific version of Puppet,
 you must set an environment variable such as:
 
 ```sh
-export PUPPET_VERSION="~> 5.5.6"
+export PUPPET_GEM_VERSION="~> 6.1.0"
 ```
 
 You can install all needed gems for spec tests into the modules directory by
@@ -232,17 +232,16 @@ simple tests against it after applying the module. You can run this
 with:
 
 ```sh
-BEAKER_setfile=debian10-x64 bundle exec rake beaker
+BEAKER_setfile=debian11-64 bundle exec rake beaker
 ```
 
 You can replace the string `debian10` with any common operating system.
 The following strings are known to work:
 
-* ubuntu1604
 * ubuntu1804
 * ubuntu2004
-* debian9
 * debian10
+* debian11
 * centos7
 * centos8
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,84 +7,12 @@ name: CI
 on: pull_request
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
-  setup_matrix:
-    name: 'Setup Test Matrix'
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    outputs:
-      puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
-      github_action_test_matrix: ${{ steps.get-outputs.outputs.github_action_test_matrix }}
-    env:
-      BUNDLE_WITHOUT: development:system_tests:release
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-      - name: Run static validations
-        run: bundle exec rake validate lint check
-      - name: Run rake rubocop
-        run: bundle exec rake rubocop
-      - name: Setup Test Matrix
-        id: get-outputs
-        run: bundle exec metadata2gha --use-fqdn --pidfile-workaround false
-
-  unit:
-    needs: setup_matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
-    env:
-      BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"
-    name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake parallel_spec
-
-  acceptance:
-    needs: setup_matrix
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_WITHOUT: development:test:release
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
-    name: ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake beaker
-        env:
-          BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
-          BEAKER_setfile: ${{ matrix.setfile.value }}
-
-  tests:
-    needs:
-      - unit
-      - acceptance
-    runs-on: ubuntu-latest
-    name: Test suite
-    steps:
-      - run: echo Test suite completed
+  puppet:
+    name: Puppet
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
+    with:
+      pidfile_workaround: 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,26 +9,14 @@ on:
     tags:
       - '*'
 
-env:
-  BUNDLE_WITHOUT: development:test:system_tests
-
 jobs:
-  deploy:
-    name: 'deploy to forge'
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'voxpupuli'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-          bundler-cache: true
-      - name: Build and Deploy
-        env:
-          # Configure secrets here:
-          #  https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets
-          BLACKSMITH_FORGE_USERNAME: '${{ secrets.PUPPET_FORGE_USERNAME }}'
-          BLACKSMITH_FORGE_API_KEY: '${{ secrets.PUPPET_FORGE_API_KEY }}'
-        run: bundle exec rake module:push
+  release:
+    name: Release
+    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v1
+    with:
+      allowed_owner: 'voxpupuli'
+    secrets:
+      # Configure secrets here:
+      #  https://docs.github.com/en/actions/security-guides/encrypted-secrets
+      username: ${{ secrets.PUPPET_FORGE_USERNAME }}
+      api_key: ${{ secrets.PUPPET_FORGE_API_KEY }}

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '5.1.0'
+modulesync_config_version: '5.3.0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /opt/puppet
 # https://github.com/puppetlabs/puppet/blob/06ad255754a38f22fb3a22c7c4f1e2ce453d01cb/lib/puppet/provider/service/runit.rb#L39
 RUN mkdir -p /etc/sv
 
-ARG PUPPET_VERSION="~> 6.0"
+ARG PUPPET_GEM_VERSION="~> 6.0"
 ARG PARALLEL_TEST_PROCESSORS=4
 
 # Cache gems

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
-  gem 'voxpupuli-test', '~> 5.0',   :require => false
+  gem 'voxpupuli-test', '~> 5.4',   :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 1.0',  :require => false
@@ -28,7 +28,7 @@ end
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_VERSION'] || '>= 6.0'
+puppetversion = ENV['PUPPET_GEM_VERSION'] || '>= 6.0'
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ begin
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not affect the functionality of the module."
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
     config.user = 'voxpupuli'
-    config.project = metadata.metadata['name']
+    config.project = 'puppet-r10k'
   end
 
   # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@ class r10k::params {
   $forge_settings            = {}
   $deploy_settings           = {}
   # Git configuration
-  $git_server = $::settings::ca_server #lint:ignore:top_scope_facts
+  $git_server = $settings::ca_server #lint:ignore:top_scope_facts
   $repo_path  = '/var/repos'
   $remote     = "ssh://${git_server}${repo_path}/modules.git"
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -155,6 +155,8 @@ class r10k::params {
   $webhook_mco_arguments         = undef
   if $facts['pe_server_version'] == '2016.4.2' {
     $webhook_sinatra_version       = '~> 1.0'
+  } elsif versioncmp(fact('ruby.version'), '2.6.0') < 0 {
+    $webhook_sinatra_version       = '~> 2.0'
   } else {
     $webhook_sinatra_version       = 'installed'
   }

--- a/spec/classes/webhook/package_spec.rb
+++ b/spec/classes/webhook/package_spec.rb
@@ -4,12 +4,47 @@ require 'spec_helper'
 describe 'r10k::webhook::package', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
+      let :ruby_version do
+        if facts[:aio_agent_version]
+          # If the facts come from some kind of AIO puppet, match the version
+          # of Ruby corresponding to the version of puppet we simulate.
+          if puppetversion[0] == '6'
+            '2.5.0'
+          else
+            '2.7.0'
+          end
+        else
+          # Otherwise, assume a recent Ruby
+          '3.0.0'
+        end
+      end
       let :facts do
-        facts
+        facts.merge(
+          is_pe: is_pe,
+          puppetversion: puppetversion,
+          ruby: {
+            version: ruby_version
+          }
+        )
       end
 
       let :pre_condition do
         "service { 'webhook.service': ensure => 'running'}"
+      end
+
+      context 'package provider' do
+        let(:is_pe) { false }
+        let(:puppetversion) { '7.10.0' }
+
+        provider = case facts[:os]['name']
+                   when 'Archlinux'
+                     'pacman'
+                   when 'Gentoo'
+                     'portage'
+                   else
+                     'puppet_gem'
+                   end
+        it { is_expected.to contain_package('sinatra').with(provider: provider) }
       end
 
       context 'Puppet Enterprise 2019.8.7' do
@@ -24,41 +59,30 @@ describe 'r10k::webhook::package', type: :class do
           )
         end
 
-        provider = case facts[:os]['name']
-                   when 'Archlinux'
-                     'pacman'
-                   when 'Gentoo'
-                     'portage'
-                   else
-                     'puppet_gem'
-                   end
-        it { is_expected.to contain_package('sinatra').with(provider: provider) }
         it { is_expected.to compile.with_all_deps }
         it { is_expected.not_to contain_package('webrick') }
         it { is_expected.not_to contain_package('json') }
       end
 
       context 'Puppet FOSS 6' do
-        let :facts do
-          facts.merge(
-            is_pe: false,
-            puppetversion: '6.24.0'
-          )
-        end
+        let(:puppetversion) { '6.24.0' }
+        let(:is_pe) { false }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_package('sinatra').with(ensure: 'installed') }
+
+        case facts[:os]['name']
+        when 'Archlinux', 'Gentoo'
+          it { is_expected.to contain_package('sinatra').with(ensure: 'installed') }
+        else
+          it { is_expected.to contain_package('sinatra').with(ensure: '~> 2.0') }
+        end
         it { is_expected.to contain_package('webrick').with(ensure: 'installed') }
         it { is_expected.to contain_package('json').with(ensure: 'installed') }
       end
 
       context 'Puppet FOSS 7' do
-        let :facts do
-          facts.merge(
-            is_pe: false,
-            puppetversion: '7.10.0'
-          )
-        end
+        let(:puppetversion) { '7.10.0' }
+        let(:is_pe) { false }
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_package('sinatra').with(ensure: 'installed') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../lib', __dir__))
 
 require 'voxpupuli/test/spec_helper'
 
+add_mocked_facts!
+
 if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
   facts = YAML.safe_load(File.read(File.join(__dir__, 'default_module_facts.yml')))
   facts&.each do |name, value|


### PR DESCRIPTION
Sinatra 3.0 was released and require Ruby 2.6+, but Puppet 6 ships with Ruby 2.5.
    
Adjust the webhook config to install sinatra 2.x if the version of Ruby does not support sinatra 3.x.  This should not affect people who already installed sinatra, so should not be a breaking change.

This PR also include:
* #580
