### PR TITLE
Add the example gen-types script from the r10k FAQ.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ _Note: It is recommended you migrate to using the `pe_r10k` module which is basi
 a clone of this modules features and file tickets for anything missing._
 
 
+### Regenerating types for changed environments
+
+A trivial script is provided to regenerate types for environment isolation:
+
+```puppet
+class { 'r10k':
+  remote  => 'git@github.com:someuser/puppet.git',
+  postrun => [ '/usr/libexec/generate-puppet-types.sh', '$modifiedenvs' ]
+  provide_generate_types_script => true,
+```
+
+r10k will automatically replace `$modifiedenvs` with any changed environment names.
+
 ### Using an internal gem server
 
 Depending on implementation requirements, there are two ways to use alternate gem sources.

--- a/files/generate-puppet-types.sh
+++ b/files/generate-puppet-types.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This file is managed by voxpupuli/puppet-r10k
+
+for environment in $@; do
+  /opt/puppetlabs/bin/puppet generate types --environment $environment
+done

--- a/manifests/gen_types_script.pp
+++ b/manifests/gen_types_script.pp
@@ -1,0 +1,12 @@
+# This class is used by the install class
+class r10k::gen_types_script (
+  Stdlib::Absolutepath $generate_types_script_location = $r10k::params::generate_types_script_location,
+) inherits r10k::params {
+  file { $generate_types_script_location:
+    ensure => 'file',
+    source => 'puppet://modules/modules/r10k/generate-puppet-types.sh',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,8 @@ class r10k (
   Optional[Integer[1]] $pool_size                             = $r10k::params::pool_size,
   Optional[String[1]] $gem_source                             = $r10k::params::gem_source,
   $root_group                                                 = $r10k::params::root_group,
+  Boolean $provide_generate_types_script                      = $r10k::params::provide_generate_types_script,
+  Stdlib::Absolutepath $generate_types_script_location        = $r10k::params::generate_types_script_location,
   $postrun                                                    = undef,
   Boolean $include_prerun_command                             = false,
   Boolean $include_postrun_command                            = false,
@@ -46,14 +48,16 @@ class r10k (
   }
 
   class { 'r10k::install':
-    install_options        => $install_options,
-    keywords               => $gentoo_keywords,
-    manage_ruby_dependency => $manage_ruby_dependency,
-    package_name           => $package_name,
-    provider               => $provider,
-    gem_source             => $gem_source,
-    version                => $version,
-    puppet_master          => $puppet_master,
+    install_options                => $install_options,
+    keywords                       => $gentoo_keywords,
+    manage_ruby_dependency         => $manage_ruby_dependency,
+    package_name                   => $package_name,
+    provider                       => $provider,
+    gem_source                     => $gem_source,
+    version                        => $version,
+    puppet_master                  => $puppet_master,
+    provide_generate_types_script  => $provide_generate_types_script,
+    generate_types_script_location => $generate_types_script_location,
   }
 
   class { 'r10k::config':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,8 @@ class r10k::install (
   $puppet_master = true,
   $is_pe_server = $r10k::params::is_pe_server,
   Optional[String[1]] $gem_source = undef,
+  Boolean $generate_types_script_location = $r10k::params::provide_generate_types_script,
+  Stdlib::Absolutepath $generate_types_script_location = $r10k::params::generate_types_script_location,
 ) inherits r10k::params {
   if $package_name == '' {
     case $provider {
@@ -63,5 +65,11 @@ class r10k::install (
       }
     }
     default: { fail("${module_name}: ${provider} is not supported. Valid values are: 'gem', 'puppet_gem', 'bundle', 'openbsd'") }
+  }
+
+  if $provide_generate_types_script {
+    class { 'r10k::gen_types_script':
+      generate_types_script_location => $generate_types_script_location,
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,6 +40,10 @@ class r10k::params {
   # Gentoo specific values
   $gentoo_keywords = ''
 
+  # A script to trivially regenerate types for changed environments
+  $provide_generate_types_script = false
+  $generate_types_script_location = '/usr/libexec/generate-puppet-types.sh'
+
   # Include the mcollective agent
   $mcollective = false
 

--- a/spec/classes/gen_types_script_spec.rb
+++ b/spec/classes/gen_types_script_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+describe 'r10k::gen_types_script', type: :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context 'with default params' do
+        it { is_expected.to compile }
+        it { is_expected.to have_file_resource_count(1) }
+        it { is_expected.to contain_file('/usr/libexec/generate-puppet-types.sh') }
+      end
+
+      context 'with script path' do
+        let(:params) do
+          {
+            'generate_types_script_location' => '/tmp/path',
+          }
+        end
+
+        it { is_expected.to compile }
+        it { is_expected.to have_file_resource_count(1) }
+        it { is_expected.to contain_file('/tmp/path') }
+      end
+    end
+  end
+end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -34,6 +34,7 @@ describe 'r10k::install' do
             provider: 'gem'
           )
         end
+        it { is_expected.not_to contain_file('/usr/libexec/generate-puppet-types.sh') }
       end
 
       context 'with gem with empty install_options', if: facts[:os]['name'] != 'Gentoo' do
@@ -56,6 +57,7 @@ describe 'r10k::install' do
             install_options: ['--no-document']
           )
         end
+        it { is_expected.not_to contain_file('/usr/libexec/generate-puppet-types.sh') }
       end
 
       context 'with gem with populated install_options', if: facts[:os]['name'] != 'Gentoo' do
@@ -78,6 +80,7 @@ describe 'r10k::install' do
             install_options: ['BOGON']
           )
         end
+        it { is_expected.not_to contain_file('/usr/libexec/generate-puppet-types.sh') }
       end
 
       context 'with puppet_gem provider' do
@@ -100,6 +103,7 @@ describe 'r10k::install' do
             provider: 'puppet_gem'
           )
         end
+        it { is_expected.not_to contain_file('/usr/libexec/generate-puppet-types.sh') }
       end
 
       context 'with puppet_gem on Puppet FOSS 4.2.1' do
@@ -133,6 +137,7 @@ describe 'r10k::install' do
             require: 'Package[r10k]'
           )
         end
+        it { is_expected.not_to contain_file('/usr/libexec/generate-puppet-types.sh') }
       end
 
       context 'with defaults and source specified', if: facts[:os]['name'] != 'Gentoo' do
@@ -158,6 +163,7 @@ describe 'r10k::install' do
             source: 'https://some.alternate.source.com/'
           )
         end
+        it { is_expected.not_to contain_file('/usr/libexec/generate-puppet-types.sh') }
       end
 
       context 'with bundle provider' do
@@ -175,6 +181,7 @@ describe 'r10k::install' do
 
         it { is_expected.to contain_class('r10k::install::bundle') }
         it { is_expected.not_to contain_package('r10k') }
+        it { is_expected.not_to contain_file('/usr/libexec/generate-puppet-types.sh') }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
The `r10k` FAQ has a simple hint for how to automate generating types for environment isolation.  Seeding this into this module (but not folks systems by default) should make it easy for folks to quickly turn on isolation without much extra work.

The README is also updated with the relevant examples.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
