### PR TITLE
update module to work with webhook-go

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,11 +8,13 @@ fixtures:
     inifile: https://github.com/puppetlabs/puppetlabs-inifile.git
     mcollective: https://github.com/choria-io/puppet-mcollective.git
     ruby: https://github.com/puppetlabs/puppetlabs-ruby.git
-    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
     systemd: https://github.com/voxpupuli/puppet-systemd.git
     vcsrepo: https://github.com/puppetlabs/puppetlabs-vcsrepo.git
     yumrepo_core: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
   forge_modules:
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: "8.6.0"
     mcollective_agent_filemgr: "choria/mcollective_agent_filemgr"
     mcollective_agent_package: "choria/mcollective_agent_package"
     mcollective_agent_puppet: "choria/mcollective_agent_puppet"

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 2.0',  :require => false
+  gem 'faraday-retry'
 end
 
 group :development do

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -17,6 +17,18 @@
 * [`r10k::params`](#r10k--params): Reasonable defaults for all classes
 * [`r10k::postrun_command`](#r10k--postrun_command): This class will configure r10k to run as part of the masters agent run
 * [`r10k::prerun_command`](#r10k--prerun_command): This class will configure r10k to run as part of the masters agent run
+* [`r10k::webhook`](#r10k--webhook): Class: r10k::webhook
+* [`r10k::webhook::config`](#r10k--webhook--config): Class: r10k::webhook::config
+* [`r10k::webhook::package`](#r10k--webhook--package): Class: r10k::webhook::package
+* [`r10k::webhook::service`](#r10k--webhook--service): Class: r10k::webhook::service
+
+### Data types
+
+* [`R10k::Webhook::Config`](#R10k--Webhook--Config)
+* [`R10k::Webhook::Config::Chatops`](#R10k--Webhook--Config--Chatops)
+* [`R10k::Webhook::Config::R10k`](#R10k--Webhook--Config--R10k)
+* [`R10k::Webhook::Config::Server`](#R10k--Webhook--Config--Server)
+* [`R10k::Webhook::Config::Server::Tls`](#R10k--Webhook--Config--Server--Tls)
 
 ### Tasks
 
@@ -823,6 +835,265 @@ Data type: `Enum['present', 'absent']`
 
 
 Default value: `'present'`
+
+### <a name="r10k--webhook"></a>`r10k::webhook`
+
+Class: r10k::webhook
+
+#### Parameters
+
+The following parameters are available in the `r10k::webhook` class:
+
+* [`ensure`](#-r10k--webhook--ensure)
+* [`version`](#-r10k--webhook--version)
+* [`service_ensure`](#-r10k--webhook--service_ensure)
+* [`service_enabled`](#-r10k--webhook--service_enabled)
+* [`config_ensure`](#-r10k--webhook--config_ensure)
+* [`config_path`](#-r10k--webhook--config_path)
+* [`chatops`](#-r10k--webhook--chatops)
+* [`tls`](#-r10k--webhook--tls)
+* [`server`](#-r10k--webhook--server)
+* [`r10k`](#-r10k--webhook--r10k)
+* [`config`](#-r10k--webhook--config)
+
+##### <a name="-r10k--webhook--ensure"></a>`ensure`
+
+Data type: `Boolean`
+
+
+
+Default value: `$r10k::params::webhook_ensure`
+
+##### <a name="-r10k--webhook--version"></a>`version`
+
+Data type: `String`
+
+
+
+Default value: `$r10k::params::webhook_version`
+
+##### <a name="-r10k--webhook--service_ensure"></a>`service_ensure`
+
+Data type:
+
+```puppet
+Variant[
+    Enum['running', 'stopped'],
+    Boolean
+  ]
+```
+
+
+
+Default value: `$r10k::params::webhook_service_ensure`
+
+##### <a name="-r10k--webhook--service_enabled"></a>`service_enabled`
+
+Data type: `Boolean`
+
+
+
+Default value: `$r10k::params::webhook_service_enabled`
+
+##### <a name="-r10k--webhook--config_ensure"></a>`config_ensure`
+
+Data type: `String`
+
+
+
+Default value: `'file'`
+
+##### <a name="-r10k--webhook--config_path"></a>`config_path`
+
+Data type: `String`
+
+
+
+Default value: `'/etc/voxpupuli/webhook.yml'`
+
+##### <a name="-r10k--webhook--chatops"></a>`chatops`
+
+Data type: `R10k::Webhook::Config::ChatOps`
+
+
+
+Default value:
+
+```puppet
+{
+    enabled    => $r10k::params::webhook_chatops_enabled,
+    service    => $r10k::params::webhook_chatops_service,
+    channel    => $r10k::params::webhook_chatops_channel,
+    user       => $r10k::params::webhook_chatops_user,
+    auth_token => $r10k::params::webhook_chatops_token,
+    server_uri => $r10k::params::webhook_chatops_uri,
+  }
+```
+
+##### <a name="-r10k--webhook--tls"></a>`tls`
+
+Data type: `R10k::Webhook::Config::Server::Tls`
+
+
+
+Default value:
+
+```puppet
+{
+    enabled     => $r10k::params::webhook_tls_enabled,
+    certificate => $r10k::params::webhook_tls_cert_path,
+    key         => $r10k::params::webhook_tls_key_path,
+  }
+```
+
+##### <a name="-r10k--webhook--server"></a>`server`
+
+Data type: `R10k::Webhook::Config::Server`
+
+
+
+Default value:
+
+```puppet
+{
+    protected => $r10k::params::webhook_protected,
+    user      => $r10k::params::webhook_user,
+    password  => $r10k::params::webhook_password,
+    port      => $r10k::params::webhook_port,
+    tls       => $tls,
+  }
+```
+
+##### <a name="-r10k--webhook--r10k"></a>`r10k`
+
+Data type: `R10k::Webhook::Config::R10k`
+
+
+
+Default value:
+
+```puppet
+{
+    command_path    => $r10k::params::webhook_r10k_command_path,
+    config_path     => $r10k::params::webhook_r10k_config_path,
+    default_branch  => $r10k::params::webhook_r10k_default_branch,
+    prefix          => $r10k::params::webhook_r10k_branch_prefix,
+    allow_uppercase => $r10k::params::webhook_r10k_allow_uppercase,
+    verbose         => $r10k::params::webhook_r10k_verbose,
+    deploy_modules  => $r10k::params::webhook_r10k_deploy_modules,
+    generate_types  => $r10k::params::webhook_r10k_generate_types,
+  }
+```
+
+##### <a name="-r10k--webhook--config"></a>`config`
+
+Data type: `R10k::Webhook::Config`
+
+
+
+Default value:
+
+```puppet
+{
+    server  => $server,
+    chatops => $chatops,
+    r10k    => $r10k,
+  }
+```
+
+### <a name="r10k--webhook--config"></a>`r10k::webhook::config`
+
+Class: r10k::webhook::config
+
+### <a name="r10k--webhook--package"></a>`r10k::webhook::package`
+
+Class: r10k::webhook::package
+
+### <a name="r10k--webhook--service"></a>`r10k::webhook::service`
+
+Class: r10k::webhook::service
+
+## Data types
+
+### <a name="R10k--Webhook--Config"></a>`R10k::Webhook::Config`
+
+The R10k::Webhook::Config data type.
+
+Alias of
+
+```puppet
+Struct[{
+    server  => Optional[R10k::Webhook::Config::Server],
+    chatops => Optional[R10k::Webhook::Config::Chatops],
+    r10k    => Optional[R10k::Webhook::Config::R10k],
+}]
+```
+
+### <a name="R10k--Webhook--Config--Chatops"></a>`R10k::Webhook::Config::Chatops`
+
+The R10k::Webhook::Config::Chatops data type.
+
+Alias of
+
+```puppet
+Struct[{
+    enabled    => Boolean,
+    service    => Optional[Enum['slack', 'rocketchat']],
+    channel    => Optional[String[1]],
+    user       => Optional[String[1]],
+    auth_token => Optional[String[1]],
+    server_uri => Optional[String[1]],
+}]
+```
+
+### <a name="R10k--Webhook--Config--R10k"></a>`R10k::Webhook::Config::R10k`
+
+The R10k::Webhook::Config::R10k data type.
+
+Alias of
+
+```puppet
+Struct[{
+    command_path    => Optional[Stdlib::Absolutepath],
+    config_path     => Optional[Stdlib::Absolutepath],
+    default_branch  => Optional[String[1]],
+    prefix          => Optional[String[1]],
+    allow_uppercase => Optional[Boolean],
+    verbose         => Optional[Boolean],
+    deploy_modules  => Optional[Boolean],
+    generate_types  => Optional[Boolean],
+}]
+```
+
+### <a name="R10k--Webhook--Config--Server"></a>`R10k::Webhook::Config::Server`
+
+The R10k::Webhook::Config::Server data type.
+
+Alias of
+
+```puppet
+Struct[{
+    protected => Boolean,
+    user      => Optional[String[1]],
+    password  => Optional[String[1]],
+    port      => Optional[Stdlib::Port],
+    tls       => Optional[R10k::Webhook::Config::Server::Tls],
+}]
+```
+
+### <a name="R10k--Webhook--Config--Server--Tls"></a>`R10k::Webhook::Config::Server::Tls`
+
+The R10k::Webhook::Config::Server::Tls data type.
+
+Alias of
+
+```puppet
+Struct[{
+    enabled     => Boolean,
+    certificate => Optional[Stdlib::Absolutepath],
+    key         => Optional[Stdlib::Absolutepath],
+}]
+```
 
 ## Tasks
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,8 @@ class r10k::params {
   $version                = 'installed'
   $manage_modulepath      = false
   $manage_ruby_dependency = 'ignore'
+  $root_user              = 'root'
+  $root_group             = 'root'
 
   $provider = $facts['os']['name'] ? {
     'Archlinux' => 'pacman',
@@ -26,6 +28,7 @@ class r10k::params {
   $r10k_cache_dir            = "${facts['puppet_vardir']}/r10k"
   $r10k_config_file          = '/etc/puppetlabs/r10k/r10k.yaml'
   $r10k_binary               = 'r10k'
+  $pre_postrun_command       = "${r10k_binary} deploy environment -p"
   $puppetconf_path           = '/etc/puppetlabs/puppet'
   $manage_configfile_symlink = false
   $configfile_symlink        = '/etc/r10k.yaml'
@@ -61,13 +64,13 @@ class r10k::params {
   if fact('is_pe') == true or fact('is_pe') == 'true' {
     # < PE 4
     $is_pe_server      = true
-  } elsif is_function_available('pe_compiling_server_version') {
-    # >= PE 4
-    $is_pe_server      = true
+    $pe_module_path = '/opt/puppetlabs/puppet/modules'
+    $modulepath = "${r10k_basedir}/\$environment/modules:${pe_module_path}"
   }
   else {
     # FOSS
     $is_pe_server      = false
+    $modulepath = "${r10k_basedir}/\$environment/modules"
   }
 
   # Webhook Go parameters

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,106 +70,29 @@ class r10k::params {
     $is_pe_server      = false
   }
 
-  if fact('pe_server_version') {
-    # PE 4 or greater specific settings
-    # r10k configuration
-
-    $pe_module_path  = '/opt/puppetlabs/puppet/modules'
-
-    # Mcollective configuration dynamic
-    $mc_service_name  = 'mcollective'
-    $plugins_dir      = '/opt/puppetlabs/mcollective/plugins/mcollective'
-    $modulepath       = "${r10k_basedir}/\$environment/modules:${pe_module_path}"
-
-    # webhook
-    $webhook_user                  = 'peadmin'
-    $webhook_pass                  = 'peadmin'
-    $webhook_group                 = 'peadmin'
-    $webhook_public_key_path       = '/var/lib/peadmin/.mcollective.d/peadmin-cert.pem'
-    $webhook_private_key_path      = '/var/lib/peadmin/.mcollective.d/peadmin-private.pem'
-    $webhook_certname              = 'peadmin'
-    $webhook_certpath              = '/var/lib/peadmin/.mcollective.d'
-    $root_user                     = 'root'
-    $root_group                    = 'root'
-  }
-  elsif versioncmp($facts['puppetversion'], '4.0.0') >= 0 {
-    #FOSS 4 or greater specific settings
-    # r10k configuration
-
-    $modulepath = "${r10k_basedir}/\$environment/modules"
-
-    # webhook
-    $webhook_user                  = 'puppet'
-    $webhook_pass                  = 'puppet'
-    $webhook_group                 = 'puppet'
-    $webhook_public_key_path       = undef
-    $webhook_private_key_path      = undef
-    $webhook_certname              = undef
-    $webhook_certpath              = undef
-    $root_user                     = 'root'
-    $root_group                    = 'root'
-  }
-  else {
-    fail("Puppet version ${facts['puppetversion']} is no longer supported. Please use an earlier version of puppet/r10k.")
-  }
-
-  # prerun_command in puppet.conf
-  $pre_postrun_command = "${r10k_binary} deploy environment -p"
-
-  # Webhook configuration information
-  $webhook_bind_address          = '*'
-  $webhook_port                  = '8088'
-  $webhook_client_cfg            = '/var/lib/peadmin/.mcollective'
-  $webhook_default_branch        = 'production'
-  $webhook_use_mco_ruby          = false
-  $webhook_protected             = true
-  $webhook_github_secret         = undef
-  $webhook_gitlab_token          = undef
-  $webhook_bitbucket_secret      = undef
-  $webhook_discovery_timeout     = 10
-  $webhook_client_timeout        = 120
-  $webhook_prefix                = false         # ':repo' | ':user' | ':command' (or true for backwards compatibility) | 'string' | false
-  $webhook_prefix_command        = '/bin/echo example'
-  $webhook_server_software       = 'WebHook'
-  $webhook_enable_ssl            = true
-  $webhook_use_mcollective       = true
-  $webhook_r10k_deploy_arguments = '-pv'
-  $webhook_bin_template          = 'r10k/webhook.bin.erb'
-  $webhook_yaml_template         = 'r10k/webhook.yaml.erb'
-  $webhook_r10k_command_prefix   = 'umask 0022;' # 'sudo' is the canonical example for this
-  $webhook_repository_events     = undef
-  $webhook_enable_mutex_lock     = false
-  $webhook_allow_uppercase       = true          # for backwards compatibility. Default to off on a major semver update.
-  $webhook_slack_webhook         = undef
-  $webhook_slack_channel         = undef
-  $webhook_slack_username        = undef
-  $webhook_slack_proxy_url       = undef
-  $webhook_slack_icon            = undef
-  $webhook_rocketchat_webhook    = undef
-  $webhook_rocketchat_channel    = undef
-  $webhook_rocketchat_username   = undef
-  $webhook_configfile_owner      = 'root'
-  $webhook_configfile_group      = $root_group
-  $webhook_configfile_mode       = '0644'
-  $webhook_ignore_environments   = []
-  $webhook_mco_arguments         = undef
-  if $facts['pe_server_version'] == '2016.4.2' {
-    $webhook_sinatra_version       = '~> 1.0'
-  } elsif versioncmp(fact('ruby.version'), '2.6.0') < 0 {
-    $webhook_sinatra_version       = '~> 2.0'
-  } else {
-    $webhook_sinatra_version       = 'installed'
-  }
-  $webhook_webrick_version       = 'installed'
-  $webhook_generate_types        = false
-
-  if $facts['os']['family'] == 'Gentoo' {
-    $webhook_service_file      = '/etc/init.d/webhook'
-    $webhook_service_file_mode = '0755'
-    $webhook_background        = true
-  } else {
-    $webhook_service_file      = '/etc/systemd/system/webhook.service'
-    $webhook_service_file_mode = '0644'
-    $webhook_background        = false
-  }
+  # Webhook Go parameters
+  $webhook_protected = true
+  $webhook_version = '2.0.1'
+  $webhook_user = 'puppet'
+  $webhook_password = 'puppet'
+  $webhook_port = 4000
+  $webhook_tls_enabled = false
+  $webhook_tls_cert = ''
+  $webhook_tls_key = ''
+  $webhook_chatops_enabled = false
+  $webhook_chatops_service = ''
+  $webhook_chatops_channel = ''
+  $webhook_chatops_user = ''
+  $webhook_chatops_token = ''
+  $webhook_chatops_uri = ''
+  $webhook_r10k_command_path = "/opt/puppetlabs/puppet/bin/${r10k_binary}"
+  $webhook_r10k_config_path = $r10k_config_file
+  $webhook_r10k_default_branch = 'production'
+  $webhook_r10k_branch_prefix = ''
+  $webhook_r10k_allow_uppercase = false
+  $webhook_r10k_verbose = true
+  $webhook_r10k_deploy_modules = true
+  $webhook_r10k_generate_types = true
+  $webhook_service_ensure = 'running'
+  $webhook_service_enabled = true
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,7 +75,7 @@ class r10k::params {
 
   # Webhook Go parameters
   $webhook_protected = true
-  $webhook_version = '2.0.1'
+  $webhook_version = '2.1.0'
   $webhook_user = 'puppet'
   $webhook_password = 'puppet'
   $webhook_port = 4000

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -2,9 +2,52 @@
 #
 #
 class r10k::webhook (
-  Boolean $ensure = true,
-  String $user = $r10k::params::webhook_user,
-  String $password = $r10k::params::webhook_password,
+  Boolean $ensure = $r10k::params::webhook_ensure,
+  String $version = $r10k::params::webhook_version,
+  Variant[
+    Enum['running', 'stopped'],
+    Boolean
+  ] $service_ensure = $r10k::params::webhook_service_ensure,
+  Boolean $service_enabled = $r10k::params::webhook_service_enabled,
+  String $config_ensure                      = 'file',
+  String $config_path                        = '/etc/voxpupuli/webhook.yml',
+  R10k::Webhook::Config::ChatOps $chatops    = {
+    enabled    => $r10k::params::webhook_chatops_enabled,
+    service    => $r10k::params::webhook_chatops_service,
+    channel    => $r10k::params::webhook_chatops_channel,
+    user       => $r10k::params::webhook_chatops_user,
+    auth_token => $r10k::params::webhook_chatops_token,
+    server_uri => $r10k::params::webhook_chatops_uri,
+  },
+  R10k::Webhook::Config::Server::Tls $tls    = {
+    enabled     => $r10k::params::webhook_tls_enabled,
+    certificate => $r10k::params::webhook_tls_cert_path,
+    key         => $r10k::params::webhook_tls_key_path,
+  },
+  R10k::Webhook::Config::Server $server      = {
+    protected => $r10k::params::webhook_protected,
+    user      => $r10k::params::webhook_user,
+    password  => $r10k::params::webhook_password,
+    port      => $r10k::params::webhook_port,
+    tls       => $tls,
+  },
+  R10k::Webhook::Config::R10k $r10k_settings = {
+    command_path    => $r10k::params::webhook_r10k_command_path,
+    config_path     => $r10k::params::webhook_r10k_config_path,
+    default_branch  => $r10k::params::webhook_r10k_default_branch,
+    prefix          => $r10k::params::webhook_r10k_branch_prefix,
+    allow_uppercase => $r10k::params::webhook_r10k_allow_uppercase,
+    verbose         => $r10k::params::webhook_r10k_verbose,
+    deploy_modules  => $r10k::params::webhook_r10k_deploy_modules,
+    generate_types  => $r10k::params::webhook_r10k_generate_types,
+  },
+  R10k::Webhook::Config $config              = {
+    server  => $server,
+    chatops => $chatops,
+    r10k    => $r10k_settings,
+  },
 ) {
-  # resources
+  contain r10k::webhook::package
+  contain r10k::webhook::config
+  contain r10k::webhook::service
 }

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -31,7 +31,7 @@ class r10k::webhook (
     port      => $r10k::params::webhook_port,
     tls       => $tls,
   },
-  R10k::Webhook::Config::R10k $r10k_settings = {
+  R10k::Webhook::Config::R10k $r10k = {
     command_path    => $r10k::params::webhook_r10k_command_path,
     config_path     => $r10k::params::webhook_r10k_config_path,
     default_branch  => $r10k::params::webhook_r10k_default_branch,
@@ -44,7 +44,7 @@ class r10k::webhook (
   R10k::Webhook::Config $config              = {
     server  => $server,
     chatops => $chatops,
-    r10k    => $r10k_settings,
+    r10k    => $r10k,
   },
 ) {
   contain r10k::webhook::package

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -1,0 +1,10 @@
+# Class: r10k::webhook
+#
+#
+class r10k::webhook (
+  Boolean $ensure = true,
+  String $user = $r10k::params::webhook_user,
+  String $password = $r10k::params::webhook_password,
+) {
+  # resources
+}

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -1,0 +1,8 @@
+# Class: r10k::webhook::config
+#
+#
+class r10k::webhook::config (
+  R10k::Webhook::Config $config
+) {
+  # resources
+}

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -2,7 +2,11 @@
 #
 #
 class r10k::webhook::config (
-  R10k::Webhook::Config $config
 ) {
-  # resources
+  file { 'webhook.yml':
+    ensure  => $r10k::webhook::config_ensure,
+    path    => $r10k::webhook::config_path,
+    content => to_yaml($r10k::webhook::config),
+    notify  => Service['webhook'],
+  }
 }

--- a/manifests/webhook/package.pp
+++ b/manifests/webhook/package.pp
@@ -1,17 +1,15 @@
 # Class: r10k::webhook::package
 #
 #
-class r10k::webhook::package (
-  String $version = '2.0.1',
-) {
-  case $facts['os']['name'] {
-    'RedHat', 'CentOS': {
+class r10k::webhook::package () {
+  case $facts['os']['family'] {
+    'RedHat': {
       $provider = 'rpm'
-      $package_url = "https://github.com/voxpupuli/webhook-go/releases/download/v${version}/webhook-go_${version}_linux_amd64.rpm"
+      $package_url = "https://github.com/voxpupuli/webhook-go/releases/download/v${r10k::webhook::version}/webhook-go_${r10k::webhook::version}_linux_amd64.rpm"
     }
     'Debian', 'Ubuntu': {
       $provider = 'dpkg'
-      $package_url = "https://github.com/voxpupuli/webhook-go/releases/download/v${version}/webhook-go_${version}_linux_amd64.deb"
+      $package_url = "https://github.com/voxpupuli/webhook-go/releases/download/v${r10k::webhook::version}/webhook-go_${r10k::webhook::version}_linux_amd64.deb"
     }
     default: {
       fail("Operating system ${facts['os']['name']} not supported for packages")
@@ -21,6 +19,6 @@ class r10k::webhook::package (
   package { 'webhook-go':
     ensure   => 'present',
     source   => $package_url,
-    proviser => $provider,
+    provider => $provider,
   }
 }

--- a/manifests/webhook/package.pp
+++ b/manifests/webhook/package.pp
@@ -1,0 +1,26 @@
+# Class: r10k::webhook::package
+#
+#
+class r10k::webhook::package (
+  String $version = '2.0.1',
+) {
+  case $facts['os']['name'] {
+    'RedHat', 'CentOS': {
+      $provider = 'rpm'
+      $package_url = "https://github.com/voxpupuli/webhook-go/releases/download/v${version}/webhook-go_${version}_linux_amd64.rpm"
+    }
+    'Debian', 'Ubuntu': {
+      $provider = 'dpkg'
+      $package_url = "https://github.com/voxpupuli/webhook-go/releases/download/v${version}/webhook-go_${version}_linux_amd64.deb"
+    }
+    default: {
+      fail("Operating system ${facts['os']['name']} not supported for packages")
+    }
+  }
+
+  package { 'webhook-go':
+    ensure   => 'present',
+    source   => $package_url,
+    proviser => $provider,
+  }
+}

--- a/manifests/webhook/service.pp
+++ b/manifests/webhook/service.pp
@@ -1,0 +1,8 @@
+# Class: r10k::webhook::service
+#
+#
+class r10k::webhook::service {
+  service { 'webhook':
+    ensure => 'running',
+  }
+}

--- a/manifests/webhook/service.pp
+++ b/manifests/webhook/service.pp
@@ -1,8 +1,9 @@
 # Class: r10k::webhook::service
 #
 #
-class r10k::webhook::service {
+class r10k::webhook::service () {
   service { 'webhook':
-    ensure => 'running',
+    ensure => $r10k::webhook::service_ensure,
+    enable => $r10k::webhook::service_enabled,
   }
 }

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -28,8 +28,11 @@ describe 'r10k::webhook' do
             user: 'puppet',
             password: 'puppet',
             port: 4000,
+            tls: {
+              enabled: false,
+            }
           },
-          r10k_settings: {
+          r10k: {
             command_path: '/opt/puppetlabs/puppet/bin/r10k',
             config_path: '/etc/puppetlabs/r10k/r10k.yaml',
             default_branch: 'production',
@@ -40,10 +43,36 @@ describe 'r10k::webhook' do
           }
         }
       end
-      if os == 'archlinux-rolling-x86_64' || os == 'gentoo-2-x86_64'
+
+      content = '---
+server:
+  protected: true
+  user: puppet
+  password: puppet
+  port: 4000
+  tls:
+    enabled: false
+chatops:
+  enabled: false
+r10k:
+  command_path: "/opt/puppetlabs/puppet/bin/r10k"
+  config_path: "/etc/puppetlabs/r10k/r10k.yaml"
+  default_branch: production
+  allow_uppercase: false
+  verbose: true
+  deploy_modules: true
+  generate_types: true
+'
+      if %w[archlinux-rolling-x86_64 gentoo-2-x86_64].include?(os)
         it { is_expected.not_to compile }
       else
         it { is_expected.to compile }
+        it { is_expected.to contain_class('r10k::webhook::package') }
+        it { is_expected.to contain_class('r10k::webhook::service') }
+        it { is_expected.to contain_class('r10k::webhook::config') }
+        it { is_expected.to contain_package('webhook-go').with_ensure('present') }
+        it { is_expected.to contain_service('webhook').with_ensure('running') }
+        it { is_expected.to contain_file('webhook.yml').with_content(content) }
       end
     end
   end

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'r10k::webhook' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      let :params do
+        {
+          ensure: true,
+          version: '1.0.0',
+          service_ensure: 'running',
+          service_enabled: true,
+          config_ensure: 'file',
+          config_path: '/etc/voxpupuli/webhook.yml',
+          chatops: {
+            enabled: false,
+          },
+          tls: {
+            enabled: false,
+          },
+          server: {
+            protected: true,
+            user: 'puppet',
+            password: 'puppet',
+            port: 4000,
+          },
+          r10k_settings: {
+            command_path: '/opt/puppetlabs/puppet/bin/r10k',
+            config_path: '/etc/puppetlabs/r10k/r10k.yaml',
+            default_branch: 'production',
+            allow_uppercase: false,
+            verbose: true,
+            deploy_modules: true,
+            generate_types: true,
+          }
+        }
+      end
+      if os == 'archlinux-rolling-x86_64' || os == 'gentoo-2-x86_64'
+        it { is_expected.not_to compile }
+      else
+        it { is_expected.to compile }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/webhook/config_spec.rb
+++ b/spec/type_aliases/webhook/config_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'R10k::Webhook::Config' do
+  context 'full valid configuration' do
+    let(:data) do
+        {
+          server: {
+            protected: true,
+            user: 'foo',
+            password: 'bar',
+            port: 4000,
+            tls: {
+              enabled: true,
+              certificate: '/some/path/to/cert.pem',
+              key: '/some/path/to/key.pem',
+            },
+          },
+          chatops: {
+            enabled: true,
+            service: 'slack',
+            channel: '#deploy',
+            user: 'baz',
+            auth_token: 'abcde',
+            server_uri: 'https://test.com/slack',
+          },
+          r10k: {
+            command_path: '/some/path/to/r10k',
+            config_path: '/some/path/to/r10k.yaml',
+            default_branch: 'main',
+            prefix: 'prefix',
+            allow_uppercase: false,
+            verbose: true,
+            deploy_modules: true,
+            generate_types: true,
+          }
+        }
+    end
+
+    it { is_expected.to allow_value(data) }
+  end
+end

--- a/spec/type_aliases/webhook/config_spec.rb
+++ b/spec/type_aliases/webhook/config_spec.rb
@@ -5,37 +5,37 @@ require 'spec_helper'
 describe 'R10k::Webhook::Config' do
   context 'full valid configuration' do
     let(:data) do
-        {
-          server: {
-            protected: true,
-            user: 'foo',
-            password: 'bar',
-            port: 4000,
-            tls: {
-              enabled: true,
-              certificate: '/some/path/to/cert.pem',
-              key: '/some/path/to/key.pem',
-            },
-          },
-          chatops: {
+      {
+        server: {
+          protected: true,
+          user: 'foo',
+          password: 'bar',
+          port: 4000,
+          tls: {
             enabled: true,
-            service: 'slack',
-            channel: '#deploy',
-            user: 'baz',
-            auth_token: 'abcde',
-            server_uri: 'https://test.com/slack',
+            certificate: '/some/path/to/cert.pem',
+            key: '/some/path/to/key.pem',
           },
-          r10k: {
-            command_path: '/some/path/to/r10k',
-            config_path: '/some/path/to/r10k.yaml',
-            default_branch: 'main',
-            prefix: 'prefix',
-            allow_uppercase: false,
-            verbose: true,
-            deploy_modules: true,
-            generate_types: true,
-          }
+        },
+        chatops: {
+          enabled: true,
+          service: 'slack',
+          channel: '#deploy',
+          user: 'baz',
+          auth_token: 'abcde',
+          server_uri: 'https://test.com/slack',
+        },
+        r10k: {
+          command_path: '/some/path/to/r10k',
+          config_path: '/some/path/to/r10k.yaml',
+          default_branch: 'main',
+          prefix: 'prefix',
+          allow_uppercase: false,
+          verbose: true,
+          deploy_modules: true,
+          generate_types: true,
         }
+      }
     end
 
     it { is_expected.to allow_value(data) }

--- a/types/webhook/config.pp
+++ b/types/webhook/config.pp
@@ -1,0 +1,5 @@
+type R10k::Webhook::Config = Struct[{
+    server  => Optional[R10k::Webhook::Config::Server],
+    chatops => Optional[R10k::Webhook::Config::Chatops],
+    r10k    => Optional[R10k::Webhook::Config::R10k],
+}]

--- a/types/webhook/config/chatops.pp
+++ b/types/webhook/config/chatops.pp
@@ -1,0 +1,8 @@
+type R10k::Webhook::Config::Chatops = Struct[{
+    enabled    => Boolean,
+    service    => Enum['slack', 'rocketchat'],
+    channel    => Optional[String[1]],
+    user       => Optional[String[1]],
+    auth_token => Optional[String[1]],
+    server_uri => Optional[String[1]],
+}]

--- a/types/webhook/config/chatops.pp
+++ b/types/webhook/config/chatops.pp
@@ -1,6 +1,6 @@
 type R10k::Webhook::Config::Chatops = Struct[{
     enabled    => Boolean,
-    service    => Enum['slack', 'rocketchat'],
+    service    => Optional[Enum['slack', 'rocketchat']],
     channel    => Optional[String[1]],
     user       => Optional[String[1]],
     auth_token => Optional[String[1]],

--- a/types/webhook/config/r10k.pp
+++ b/types/webhook/config/r10k.pp
@@ -1,0 +1,10 @@
+type R10k::Webhook::Config::R10k = Struct[{
+    command_path    => Optional[Stdlib::Absolutepath],
+    config_path     => Optional[Stdlib::Absolutepath],
+    default_branch  => Optional[String[1]],
+    prefix          => Optional[String[1]],
+    allow_uppercase => Optional[Boolean],
+    verbose         => Optional[Boolean],
+    deploy_modules  => Optional[Boolean],
+    generate_types  => Optional[Boolean],
+}]

--- a/types/webhook/config/server.pp
+++ b/types/webhook/config/server.pp
@@ -1,0 +1,7 @@
+type R10k::Webhook::Config::Server = Struct[{
+    protected => Boolean,
+    user      => Optional[String[1]],
+    password  => Optional[String[1]],
+    port      => Optional[Stdlib::Port],
+    tls       => Optional[R10k::Webhook::Config::Server::Tls],
+}]

--- a/types/webhook/config/server/tls.pp
+++ b/types/webhook/config/server/tls.pp
@@ -1,0 +1,5 @@
+type R10k::Webhook::Config::Server::Tls = Struct[{
+    enabled     => Boolean,
+    certificate => Optional[Stdlib::Absolutepath],
+    key         => Optional[Stdlib::Absolutepath],
+}]


### PR DESCRIPTION
#### Pull Request (PR) description

This PR will contain all the changes necessary to migrate the code over to using `voxpupuli/webhook-go` for the webhook server.

#### This Pull Request (PR) fixes the following issues
* Add new type aliases for the Webhook Go configuration file
  * `R10k::Webhook::Config`
  * `R10k::Webhook::Config::Server`
  * `R10k::Webhook::Config::Server::Tls`
  * `R10k::Webhook::Config::Chatops`
  * `R10k::Webhook::Config::R10k`
* Add test for new type aliases
* Update `manifests/webhook/config.pp` to use the new type aliases for
  config generation. This should map almost 1:1 with the config file
  format
* Install Webhook Go from GitHub Releases page using RPM or DPKG. No
  repos or other install options yet.
* Update Params to remove no longer used options.


