### PR TITLE
Bugfix: Fix service name of webhook-go service

### DIFF
--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -7,6 +7,6 @@ class r10k::webhook::config (
     ensure  => $r10k::webhook::config_ensure,
     path    => $r10k::webhook::config_path,
     content => to_yaml($r10k::webhook::config),
-    notify  => Service['webhook'],
+    notify  => Service['webhook-go'],
   }
 }

--- a/manifests/webhook/service.pp
+++ b/manifests/webhook/service.pp
@@ -2,7 +2,7 @@
 #
 #
 class r10k::webhook::service () {
-  service { 'webhook':
+  service { 'webhook-go':
     ensure => $r10k::webhook::service_ensure,
     enable => $r10k::webhook::service_enabled,
   }

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -82,7 +82,7 @@ r10k:
         it { is_expected.to contain_class('r10k::webhook::service') }
         it { is_expected.to contain_class('r10k::webhook::config') }
         it { is_expected.to contain_package('webhook-go').with_ensure('present') }
-        it { is_expected.to contain_service('webhook').with_ensure('running') }
+        it { is_expected.to contain_service('webhook-go').with_ensure('running') }
         it { is_expected.to contain_file('webhook.yml').with_content(content) }
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The name of the systemd unit for the webhook service in the webhook-go package is named `webhook-go`. In the manifests and test, the legacy name `webhook` was still used. This PR fixes this.
Unit file at project voxpupuli/webhook-go: https://github.com/voxpupuli/webhook-go/blob/v2.1.0/build/webhook-go.service
