### PR TITLE
deploy settings: generate types by default and dont deploy spec dir

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -227,7 +227,7 @@ Default value: `$r10k::params::forge_settings`
 
 ##### <a name="-r10k--deploy_settings"></a>`deploy_settings`
 
-Data type: `Optional[Hash]`
+Data type: `Hash`
 
 
 
@@ -466,7 +466,7 @@ Default value: `$r10k::params::forge_settings`
 
 ##### <a name="-r10k--config--deploy_settings"></a>`deploy_settings`
 
-Data type: `Optional[Hash]`
+Data type: `Hash`
 
 
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -63,7 +63,7 @@ class r10k::config (
   Stdlib::Absolutepath $configfile_symlink  = $r10k::params::configfile_symlink,
   Optional[Hash] $git_settings              = $r10k::params::git_settings,
   Optional[Hash] $forge_settings            = $r10k::params::forge_settings,
-  Optional[Hash] $deploy_settings           = $r10k::params::deploy_settings,
+  Hash $deploy_settings                     = $r10k::params::deploy_settings,
   Optional[Array[String[1]]] $postrun       = $r10k::params::postrun,
   $root_user                                = $r10k::params::root_user,
   $root_group                               = $r10k::params::root_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class r10k (
   $configfile_symlink                                         = $r10k::params::configfile_symlink,
   Optional[Hash] $git_settings                                = $r10k::params::git_settings,
   Optional[Hash] $forge_settings                              = $r10k::params::forge_settings,
-  Optional[Hash] $deploy_settings                             = $r10k::params::deploy_settings,
+  Hash $deploy_settings                                       = $r10k::params::deploy_settings,
   $root_user                                                  = $r10k::params::root_user,
   Optional[String[1]] $proxy                                  = $r10k::params::proxy,
   Optional[Integer[1]] $pool_size                             = $r10k::params::pool_size,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class r10k::params {
   $configfile_symlink        = '/etc/r10k.yaml'
   $git_settings              = undef
   $forge_settings            = undef
-  $deploy_settings           = undef
+  $deploy_settings           = { 'generate_types' => true, 'exclude_spec' => true, }
   # Git configuration
   $git_server = $settings::ca_server #lint:ignore:top_scope_facts
   $repo_path  = '/var/repos'


### PR DESCRIPTION
for a long time r10k supports generating types. It's not required to do this in a custom posthook. Also r10k has an option to ignore the spec dir from modules. To provide a good user experience we should enable it.

This was introduced in r10k 3.11: https://github.com/puppetlabs/r10k/blob/main/CHANGELOG.mkd#3110

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
