### PR TITLE
pre_postrun_command: replace deprecated `--puppetfile` with `--modules`

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,7 +29,7 @@ class r10k::params {
   $r10k_cache_dir            = "${facts['puppet_vardir']}/r10k"
   $r10k_config_file          = '/etc/puppetlabs/r10k/r10k.yaml'
   $r10k_binary               = 'r10k'
-  $pre_postrun_command       = "${r10k_binary} deploy environment -p"
+  $pre_postrun_command       = "${r10k_binary} deploy environment --modules"
   $puppetconf_path           = '/etc/puppetlabs/puppet'
   $manage_configfile_symlink = false
   $configfile_symlink        = '/etc/r10k.yaml'

--- a/spec/classes/postrun_command_spec.rb
+++ b/spec/classes/postrun_command_spec.rb
@@ -65,7 +65,7 @@ describe 'r10k::postrun_command', type: :class do
               ensure: 'present',
               section: 'agent',
               setting: 'postrun_command',
-              value: 'r10k deploy environment -p'
+              value: 'r10k deploy environment --modules'
             )
           end
         end

--- a/spec/classes/prerun_command_spec.rb
+++ b/spec/classes/prerun_command_spec.rb
@@ -65,7 +65,7 @@ describe 'r10k::prerun_command', type: :class do
               ensure: 'present',
               section: 'agent',
               setting: 'prerun_command',
-              value: 'r10k deploy environment -p'
+              value: 'r10k deploy environment --modules'
             )
           end
         end


### PR DESCRIPTION
r10k deprecated the `-p` / `--puppetfile` option. The successor is `-m` / `--modules`.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
