### PR TITLE
webhook: Update default version 2.1.0->2.2.0

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -592,7 +592,7 @@ Data type: `String`
 
 
 
-Default value: `'2.1.0'`
+Default value: `'2.2.0'`
 
 ##### <a name="-r10k--webhook--service_ensure"></a>`service_ensure`
 

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -6,7 +6,7 @@
 class r10k::webhook (
   Enum['package', 'repo', 'none'] $install_method = 'package',
   Boolean $ensure = false,
-  String $version = '2.1.0',
+  String $version = '2.2.0',
   Variant[
     Enum['running', 'stopped'],
     Boolean


### PR DESCRIPTION
This fixes a bug in the systemd unit. That's a requirement to enable acceptance tests.