### PR TITLE
replace to_yaml() with stdlib::to_yaml()

### DIFF
--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -6,7 +6,7 @@ class r10k::webhook::config (
   file { 'webhook.yml':
     ensure  => $r10k::webhook::config_ensure,
     path    => $r10k::webhook::config_path,
-    content => to_yaml($r10k::webhook::config),
+    content => stdlib::to_yaml($r10k::webhook::config),
     notify  => Service['webhook-go'],
   }
 }


### PR DESCRIPTION
sine puppetlabs/stdlib 9 to_yaml() is deprecated and stdlib::to_yaml() is the successor. This isn't a breaking change because we already use stdlib::to_yaml() in other places in this module.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
