### PR TITLE
Update ordering on webhook and docu

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ class { 'r10k::webhook':
 To aid in debugging, or to give you some hints as to how to trigger the webhook by unsupported systems, here's a curl command to trigger the webhook to deploy the 'production' environment:
 
 ```bash
-curl -d '
+curl --header "X-Gitlab-Event: Push Hook" -d '
   {
     "repository": {"name": "foo", "owner": {"login": "foo"}},
     "ref": "production"
@@ -549,7 +549,7 @@ curl -d '
 If you are utilizing environment prefixes, you'll need to specify the full environment title (including the prefix) in the 'ref' parameter:
 
 ```bash
-curl -d '
+curl --header "X-Gitlab-Event: Push Hook" -d '
   {
     "repository": {"name": "bar", "owner": {"login": "foo"}},
     "ref": "bar_production"

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -53,4 +53,8 @@ class r10k::webhook (
   contain r10k::webhook::package
   contain r10k::webhook::config
   contain r10k::webhook::service
+
+  Class['r10k::webhook::package']
+  -> Class['r10k::webhook::config']
+  ~> Class['r10k::webhook::service']
 }

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -7,6 +7,5 @@ class r10k::webhook::config (
     ensure  => $r10k::webhook::config_ensure,
     path    => $r10k::webhook::config_path,
     content => stdlib::to_yaml($r10k::webhook::config),
-    notify  => Service['webhook-go'],
   }
 }


### PR DESCRIPTION
webhook classes must be in order to ensure package and config prior service
update documentation on webhook-go curl command.

fixes #637

