### PR TITLE
Add Support for r10k 4 & 5

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,14 @@ class r10k::params {
     'OpenBSD' => 'ruby31-r10k',
     default   => 'r10k'
   }
-  $version                = 'installed'
+  # 4.1.0 is the oldest version that supports ruby >=2.6.0
+  # That's required on Puppet 7
+  # pacman provider has no versionable flag
+  $version = if versioncmp($facts['puppetversion'], '8.0.0') < 0 and $facts['os']['name'] != 'Archlinux' {
+    '4.1.0'
+  } else {
+    'installed'
+  }
   $manage_modulepath      = false
   $root_user              = 'root'
   $root_group             = 'root'

--- a/spec/acceptance/r10k_spec.rb
+++ b/spec/acceptance/r10k_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'r10k tests' do
+  context 'when defaults used' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+        include 'r10k'
+        PUPPET
+      end
+    end
+
+    describe command('r10k version') do
+      its(:stdout) { is_expected.to match(%r{r10k 4}) } if fact('puppetversion')[0] == '7'
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+
+    describe file('//etc/puppetlabs/r10k/r10k.yaml') do
+      it 'exists and has content' do
+        expect(subject).to exist
+        expect(subject).to be_owned_by 'root'
+        expect(subject).to be_grouped_into 'root'
+      end
+    end
+  end
+end


### PR DESCRIPTION
r10k 5 requires Ruby 3.1 or Puppet 8.

