### PR TITLE
(metadata.json) allow puppetlabs-vcsrepo 7.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -81,7 +81,7 @@
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">= 1.3.1 < 7.0.0"
+      "version_requirement": ">= 1.3.1 < 8.0.0"
     },
     {
       "name": "choria/mcollective",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Bump version of VCS Repo to include 7.x

#### This Pull Request (PR) fixes the following issues
Allows users who use VCS Repo module version 7.x to also use this module