### PR TITLE
Add support for webhook queue options

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -32,6 +32,7 @@
 * [`R10k::Webhook::Config::Chatops`](#R10k--Webhook--Config--Chatops): webhook config chatops type
 * [`R10k::Webhook::Config::R10k`](#R10k--Webhook--Config--R10k): webhook config r10k type
 * [`R10k::Webhook::Config::Server`](#R10k--Webhook--Config--Server): webhook config server type
+* [`R10k::Webhook::Config::Server::Queue`](#R10k--Webhook--Config--Server--Queue): webhook config server queue type
 * [`R10k::Webhook::Config::Server::Tls`](#R10k--Webhook--Config--Server--Tls): webhook config server tls type
 
 ### Tasks
@@ -533,6 +534,7 @@ The following parameters are available in the `r10k::webhook` class:
 * [`config_path`](#-r10k--webhook--config_path)
 * [`chatops`](#-r10k--webhook--chatops)
 * [`tls`](#-r10k--webhook--tls)
+* [`queue`](#-r10k--webhook--queue)
 * [`server`](#-r10k--webhook--server)
 * [`r10k`](#-r10k--webhook--r10k)
 * [`config`](#-r10k--webhook--config)
@@ -635,6 +637,22 @@ Default value:
   }
 ```
 
+##### <a name="-r10k--webhook--queue"></a>`queue`
+
+Data type: `R10k::Webhook::Config::Server::Queue`
+
+
+
+Default value:
+
+```puppet
+{
+    enabled             => false,
+    max_concurrent_jobs => undef,
+    max_history_items   => undef,
+  }
+```
+
 ##### <a name="-r10k--webhook--server"></a>`server`
 
 Data type: `R10k::Webhook::Config::Server`
@@ -650,6 +668,7 @@ Default value:
     password  => 'puppet',
     port      => 4000,
     tls       => $tls,
+    queue     => $queue,
   }
 ```
 
@@ -767,6 +786,21 @@ Struct[{
     password  => Optional[String[1]],
     port      => Optional[Stdlib::Port],
     tls       => Optional[R10k::Webhook::Config::Server::Tls],
+    queue     => Optional[R10k::Webhook::Config::Server::Queue],
+}]
+```
+
+### <a name="R10k--Webhook--Config--Server--Queue"></a>`R10k::Webhook::Config::Server::Queue`
+
+webhook config server queue type
+
+Alias of
+
+```puppet
+Struct[{
+    enabled             => Boolean,
+    max_concurrent_jobs => Optional[Integer],
+    max_history_items   => Optional[Integer],
 }]
 ```
 

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -10,6 +10,7 @@
 # @param config_path
 # @param chatops
 # @param tls
+# @param queue
 # @param server
 # @param r10k
 # @param config
@@ -38,12 +39,18 @@ class r10k::webhook (
     certificate => undef,
     key         => undef,
   },
+  R10k::Webhook::Config::Server::Queue $queue    = {
+    enabled             => false,
+    max_concurrent_jobs => undef,
+    max_history_items   => undef,
+  },
   R10k::Webhook::Config::Server $server      = {
     protected => true,
     user      => 'puppet',
     password  => 'puppet',
     port      => 4000,
     tls       => $tls,
+    queue     => $queue,
   },
   R10k::Webhook::Config::R10k $r10k = {
     command_path    => '/opt/puppetlabs/puppet/bin/r10k',

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -49,6 +49,11 @@ describe 'r10k::webhook' do
                 certificate: '/path/to/cert',
                 key: '/path/to/key',
               },
+              queue: {
+                enabled: true,
+                max_concurrent_jobs: 10,
+                max_history_items: 20,
+              }
             },
             r10k: {
               command_path: '/opt/puppetlabs/puppet/bin/r10k',
@@ -72,6 +77,10 @@ server:
     enabled: true
     certificate: "/path/to/cert"
     key: "/path/to/key"
+  queue:
+    enabled: true
+    max_concurrent_jobs: 10
+    max_history_items: 20
 chatops:
   enabled: true
   service: slack

--- a/spec/type_aliases/webhook/config_spec.rb
+++ b/spec/type_aliases/webhook/config_spec.rb
@@ -16,6 +16,11 @@ describe 'R10k::Webhook::Config' do
             certificate: '/some/path/to/cert.pem',
             key: '/some/path/to/key.pem',
           },
+          queue: {
+            enabled: true,
+            max_concurrent_jobs: 10,
+            max_history_items: 20,
+          },
         },
         chatops: {
           enabled: true,

--- a/types/webhook/config/server.pp
+++ b/types/webhook/config/server.pp
@@ -5,4 +5,5 @@ type R10k::Webhook::Config::Server = Struct[{
     password  => Optional[String[1]],
     port      => Optional[Stdlib::Port],
     tls       => Optional[R10k::Webhook::Config::Server::Tls],
+    queue     => Optional[R10k::Webhook::Config::Server::Queue],
 }]

--- a/types/webhook/config/server/queue.pp
+++ b/types/webhook/config/server/queue.pp
@@ -1,0 +1,6 @@
+# @summary webhook config server queue type
+type R10k::Webhook::Config::Server::Queue = Struct[{
+    enabled             => Boolean,
+    max_concurrent_jobs => Optional[Integer],
+    max_history_items   => Optional[Integer],
+}]


### PR DESCRIPTION
#### Pull Request (PR) description
Support for Webhook queue: https://github.com/voxpupuli/webhook-go?tab=readme-ov-file#queue

#### This Pull Request (PR) fixes the following issues
The option was not present.
The option is disabled as default, like on the webhook-go defaults. 