### PR TITLE
Remove dependency to mcollective module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,6 @@ fixtures:
     choria: https://github.com/choria-io/puppet-choria.git
     concat: https://github.com/puppetlabs/puppetlabs-concat.git
     cron_core: https://github.com/puppetlabs/puppetlabs-cron_core.git
-    git: https://github.com/puppetlabs/puppetlabs-git.git
     inifile: https://github.com/puppetlabs/puppetlabs-inifile.git
     mcollective: https://github.com/choria-io/puppet-mcollective.git
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -171,7 +171,8 @@ Default value: `[]`
 
 Data type: `Boolean`
 
-
+Install the r10k mcollective agent
+Requires the choria/mcollective module to be installed
 
 Default value: `$r10k::params::mcollective`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,8 @@
 # @param gentoo_keywords
 # @param install_options
 # @param mcollective
+#   Install the r10k mcollective agent
+#   Requires the choria/mcollective module to be installed
 # @param git_settings
 # @param deploy_settings
 # @param root_user

--- a/metadata.json
+++ b/metadata.json
@@ -84,10 +84,6 @@
       "version_requirement": ">= 1.3.1 < 8.0.0"
     },
     {
-      "name": "choria/mcollective",
-      "version_requirement": ">= 0.10.0 <1.0.0"
-    },
-    {
       "name": "puppet/systemd",
       "version_requirement": ">= 3.2.0 < 9.0.0"
     }


### PR DESCRIPTION
#### Pull Request (PR) description

Using mcollective with r10k is optional.

Given the fact that the choria/mcollective module has not seen a new release in a year and by that does not support puppet/systemd 8.x, I think this module is better off having a 'soft' dependency to the module.
