### PR TITLE
Fix arm64 package download, allow direct download

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -581,7 +581,7 @@ Data type: `String[1]`
 
 
 
-Default value: `'2.10.0'`
+Default value: `'2.14.3'`
 
 ##### <a name="-r10k--webhook--service_ensure"></a>`service_ensure`
 

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -21,7 +21,7 @@ class r10k::webhook (
   Optional $service_user = undef,
   Enum['package', 'repo', 'none'] $install_method = 'package',
   Boolean $ensure = false,
-  String[1] $version = '2.10.0',
+  String[1] $version = '2.14.3',
   Variant[
     Enum['running', 'stopped'],
     Boolean

--- a/manifests/webhook/package.pp
+++ b/manifests/webhook/package.pp
@@ -4,32 +4,50 @@
 class r10k::webhook::package () {
   case $r10k::webhook::install_method { # lint:ignore:case_without_default
     'package': {
+      # Work out the remote package name
+      $pkg_prefix = 'https://github.com/voxpupuli/webhook-go/releases/download'
+      $pkg_arch = $facts['os']['architecture'] ? {
+        'aarch64' => 'arm64',
+        default   => 'amd64',
+      }
+      $pkg_base = "${pkg_prefix}/v${r10k::webhook::version}/webhook-go_${r10k::webhook::version}_linux_${pkg_arch}"
+
       case $facts['os']['family'] {
         'RedHat': {
-          $provider = 'rpm'
-          $pkg_file = '/tmp/webhook-go.rpm'
-          $package_url = "https://github.com/voxpupuli/webhook-go/releases/download/v${r10k::webhook::version}/webhook-go_${r10k::webhook::version}_linux_amd64.rpm"
+          $pkg_url  = "${pkg_base}.rpm"
+          if $facts['package_provider'] == 'dnf' {
+            $pkg_file = undef
+          } else {
+            $provider = 'rpm'
+            $pkg_file = '/tmp/webhook-go.rpm'
+          }
         }
         'Debian', 'Ubuntu': {
           $provider = 'dpkg'
           $pkg_file = '/tmp/webhook-go.deb'
-          $package_url = "https://github.com/voxpupuli/webhook-go/releases/download/v${r10k::webhook::version}/webhook-go_${r10k::webhook::version}_linux_amd64.deb"
+          $pkg_url  = "${pkg_base}.deb"
         }
         default: {
           fail("Operating system ${facts['os']['name']} not supported for packages")
         }
       }
 
-      file { $pkg_file:
-        ensure => file,
-        source => $package_url,
-        before => Package['webhook-go'],
-      }
-
-      package { 'webhook-go':
-        ensure   => 'present',
-        source   => $pkg_file,
-        provider => $provider,
+      if $pkg_file {
+        file { $pkg_file:
+          ensure => file,
+          source => $pkg_url,
+          before => Package['webhook-go'],
+        }
+        package { 'webhook-go':
+          ensure   => 'present',
+          source   => $pkg_file,
+          provider => $provider,
+        }
+      } else {
+        package { 'webhook-go':
+          ensure => 'present',
+          source => $pkg_url,
+        }
       }
     }
     'repo': {

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -13,12 +13,20 @@ describe 'r10k::webhook' do
         if %w[archlinux-rolling-x86_64 archlinux-6-x86_64 gentoo-2-x86_64].include?(os)
           it { is_expected.not_to compile }
         else
+          package_url = 'https://github.com/voxpupuli/webhook-go/releases/download/v2.14.3/webhook-go_2.14.3_linux_amd64'
+
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('r10k::webhook::package') }
           it { is_expected.to contain_class('r10k::webhook::service') }
           it { is_expected.to contain_class('r10k::webhook::config') }
           it { is_expected.to contain_package('webhook-go').with_ensure('present') }
           it { is_expected.to contain_service('webhook-go.service').with_ensure('running') }
+
+          if os_facts[:os]['family'] == 'RedHat'
+            it { is_expected.to contain_file('/tmp/webhook-go.rpm').with_source("#{package_url}.rpm") }
+          elsif os_facts[:os]['family'] == 'Debian'
+            it { is_expected.to contain_file('/tmp/webhook-go.deb').with_source("#{package_url}.deb") }
+          end
         end
       end
 
@@ -111,12 +119,16 @@ mappings: {}
             it { is_expected.not_to contain_systemd__dropin_file('user.conf') }
             it { is_expected.to contain_file('webhook.yml').with_content(content) }
 
+            package_url = 'https://github.com/voxpupuli/webhook-go/releases/download/v1.0.0/webhook-go_1.0.0_linux_amd64'
+
             if os_facts[:os]['family'] == 'RedHat'
-              it { is_expected.to contain_file('/tmp/webhook-go.rpm') }
+              it { is_expected.to contain_file('/tmp/webhook-go.rpm').with(ensure: 'file', source: "#{package_url}.rpm") }
               it { is_expected.not_to contain_file('/tmp/webhook-go.deb') }
+              it { is_expected.to contain_package('webhook-go').with(source: '/tmp/webhook-go.rpm', provider: 'rpm') }
             elsif os_facts[:os]['family'] == 'Debian'
               it { is_expected.not_to contain_file('/tmp/webhook-go.rpm') }
-              it { is_expected.to contain_file('/tmp/webhook-go.deb') }
+              it { is_expected.to contain_file('/tmp/webhook-go.deb').with(ensure: 'file', source: "#{package_url}.deb") }
+              it { is_expected.to contain_package('webhook-go').with(source: '/tmp/webhook-go.deb', provider: 'dpkg') }
             end
           end
         end
@@ -141,6 +153,37 @@ mappings: {}
           end
         end
       end
+    end
+  end
+
+  context 'on Debian aarch64' do
+    let :facts do
+      os_facts = on_supported_os['debian-12-x86_64']
+      os_facts.merge(os: os_facts[:os].merge('architecture' => 'aarch64'))
+    end
+
+    it { is_expected.to compile.with_all_deps }
+
+    it do
+      is_expected.to contain_file('/tmp/webhook-go.deb').with_source(
+        'https://github.com/voxpupuli/webhook-go/releases/download/v2.14.3/webhook-go_2.14.3_linux_arm64.deb',
+      )
+    end
+  end
+
+  context 'on RedHat with the dnf package provider' do
+    let :facts do
+      on_supported_os['redhat-9-x86_64'].merge(package_provider: 'dnf')
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.not_to contain_file('/tmp/webhook-go.rpm') }
+
+    it do
+      is_expected.to contain_package('webhook-go').with(
+        ensure: 'present',
+        source: 'https://github.com/voxpupuli/webhook-go/releases/download/v2.14.3/webhook-go_2.14.3_linux_amd64.rpm',
+      )
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

* Check the architecture and download the appropriate package
* If the package provider is DNF do direct download vs staging a file
* Update webhook-go version to latest release

#### This Pull Request (PR) fixes the following issues

1. Staging a file in tmp is vulnerable to race conditions, and is completely unnecessary on any RedHat family node created in the last decade
2. Current head tries to download amd64 package even when running on aarch64

```
Error: Execution of '/usr/bin/rpm -i /tmp/webhook-go.rpm' returned 1: package webhook-go-2.14.3-1.x86_64 is intended for a different architecture
Error: /Stage[main]/R10k::Webhook::Package/Package[webhook-go]/ensure: change from 'absent' to 'present' failed: Execution of '/usr/bin/rpm -i /tmp/webhook-go.rpm' returned 1: package webhook-go-2.14.3-1.x86_64 is intended for a different architecture
```

