### PR TITLE
Allow use of short-term git tokens with r10k

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,16 @@ For version control systems that use web driven post-receive processes you can u
 When the webhook receives the post-receive event, it will synchronize environments on your puppet masters.
 These settings are all configurable for your specific use case, as shown below in these configuration examples.
 
+For git repositories accessed with short-term tokens provided by a CD pipeline, provide the path to a token file.
+This allows dynamic token replacement without reconfiguring r10k. When supplied,
+the module configures a git credential helper to supply the token for webhook-triggered r10k runs.
+
+```puppet
+class { 'r10k::webhook':
+  github_token_path => '/run/r10k/github.token',
+}
+```
+
 **NOTE: MCollective and Bolt aren't currently supported with Webhook Go. This will be addressed in a future release of Webhook Go, but is an issue related to the complex nature of Bolt and MCollective/Choria commands that cause issues with the way Go executes shell commands.**
 
 ### Webhook Github Enterprise - Non Authenticated

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -536,6 +536,7 @@ install and configure the webhook-go package as local webhook receiver to trigge
 The following parameters are available in the `r10k::webhook` class:
 
 * [`service_user`](#-r10k--webhook--service_user)
+* [`github_token_path`](#-r10k--webhook--github_token_path)
 * [`install_method`](#-r10k--webhook--install_method)
 * [`ensure`](#-r10k--webhook--ensure)
 * [`version`](#-r10k--webhook--version)
@@ -556,6 +557,15 @@ The following parameters are available in the `r10k::webhook` class:
 Data type: `Optional`
 
 the user that should run the service
+
+Default value: `undef`
+
+##### <a name="-r10k--webhook--github_token_path"></a>`github_token_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Path to a file containing a GitHub token used by webhook-triggered r10k runs.
+This could be a short-term, single-use token replaced before each run.
 
 Default value: `undef`
 
@@ -661,7 +671,8 @@ Default value:
 
 Data type: `R10k::Webhook::Config::Server::Queue`
 
-
+Accept a job and return success immediately. This can hide deployment failures,
+and will not work in situations where a deployment token lifetime matches the caller's lifetime.
 
 Default value:
 

--- a/manifests/webhook.pp
+++ b/manifests/webhook.pp
@@ -1,6 +1,9 @@
 # @summary install and configure the webhook-go package as local webhook receiver to trigger r10k runs
 #
 # @param service_user the user that should run the service
+# @param github_token_path
+#   Path to a file containing a GitHub token used by webhook-triggered r10k runs.
+#   This could be a short-term, single-use token replaced before each run.
 # @param install_method
 #   how the package should be installed
 # @param ensure
@@ -12,6 +15,8 @@
 # @param chatops
 # @param tls
 # @param queue
+#   Accept a job and return success immediately. This can hide deployment failures,
+#   and will not work in situations where a deployment token lifetime matches the caller's lifetime.
 # @param server
 # @param r10k
 # @param mappings
@@ -19,6 +24,7 @@
 #
 class r10k::webhook (
   Optional $service_user = undef,
+  Optional[Stdlib::Absolutepath] $github_token_path = undef,
   Enum['package', 'repo', 'none'] $install_method = 'package',
   Boolean $ensure = false,
   String[1] $version = '2.14.3',

--- a/manifests/webhook/config.pp
+++ b/manifests/webhook/config.pp
@@ -3,6 +3,13 @@
 #
 class r10k::webhook::config (
 ) {
+  file { '/etc/voxpupuli':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
   file { 'webhook.yml':
     ensure  => $r10k::webhook::config_ensure,
     path    => $r10k::webhook::config_path,
@@ -10,5 +17,29 @@ class r10k::webhook::config (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
+  }
+
+  if $r10k::webhook::github_token_path {
+    file { '/etc/voxpupuli/r10k-git-credential-helper':
+      ensure  => file,
+      owner   => 'root',
+      group   => $r10k::webhook::service_user,
+      mode    => '0550',
+      content => epp('r10k/r10k-git-credential-helper.epp', {
+        'token_path' => shellquote($r10k::webhook::github_token_path),
+      }),
+    }
+
+    file { '/etc/voxpupuli/r10k.gitconfig':
+      ensure  => file,
+      owner   => 'root',
+      group   => $r10k::webhook::service_user,
+      mode    => '0440',
+      content => "[credential \"https://github.com\"]\n  helper = /etc/voxpupuli/r10k-git-credential-helper\n",
+      require => [
+        File['/etc/voxpupuli'],
+        File['/etc/voxpupuli/r10k-git-credential-helper'],
+      ],
+    }
   }
 }

--- a/manifests/webhook/service.pp
+++ b/manifests/webhook/service.pp
@@ -6,10 +6,15 @@ class r10k::webhook::service () {
     ensure => $r10k::webhook::service_ensure,
     enable => $r10k::webhook::service_enabled,
   }
-  if $r10k::webhook::service_user {
-    systemd::dropin_file { 'user.conf':
-      unit    => 'webhook-go.service',
-      content => "[Service]\nUser=${r10k::webhook::service_user}\n",
-    }
+
+  systemd::dropin_file { 'webhook-go.service-override':
+    unit     => 'webhook-go.service',
+    filename => 'override.conf',
+    content  => epp('r10k/webhook-service-override.epp', {
+      'service_user'      => $r10k::webhook::service_user,
+      'github_token_path' => $r10k::webhook::github_token_path,
+    }),
+    require  => Class['r10k::webhook::config'],
+    notify   => Service['webhook-go.service'],
   }
 }

--- a/spec/classes/webhook_spec.rb
+++ b/spec/classes/webhook_spec.rb
@@ -21,6 +21,16 @@ describe 'r10k::webhook' do
           it { is_expected.to contain_class('r10k::webhook::config') }
           it { is_expected.to contain_package('webhook-go').with_ensure('present') }
           it { is_expected.to contain_service('webhook-go.service').with_ensure('running') }
+          it { is_expected.to contain_file('/etc/voxpupuli').with_ensure('directory') }
+          it { is_expected.not_to contain_file('/etc/voxpupuli/r10k.gitconfig') }
+          it { is_expected.not_to contain_file('/etc/voxpupuli/r10k-git-credential-helper') }
+
+          it do
+            is_expected.to contain_systemd__dropin_file('webhook-go.service-override').with(
+              filename: 'override.conf',
+              content: "[Service]\n",
+            )
+          end
 
           if os_facts[:os]['family'] == 'RedHat'
             it { is_expected.to contain_file('/tmp/webhook-go.rpm').with_source("#{package_url}.rpm") }
@@ -116,7 +126,14 @@ mappings: {}
             it { is_expected.to contain_class('r10k::webhook::config') }
             it { is_expected.to contain_package('webhook-go').with_ensure('present') }
             it { is_expected.to contain_service('webhook-go.service').with_ensure('running') }
-            it { is_expected.not_to contain_systemd__dropin_file('user.conf') }
+
+            it do
+              is_expected.to contain_systemd__dropin_file('webhook-go.service-override').with(
+                filename: 'override.conf',
+                content: "[Service]\n",
+              )
+            end
+
             it { is_expected.to contain_file('webhook.yml').with_content(content) }
 
             package_url = 'https://github.com/voxpupuli/webhook-go/releases/download/v1.0.0/webhook-go_1.0.0_linux_amd64'
@@ -149,7 +166,93 @@ mappings: {}
           if %w[archlinux-rolling-x86_64 archlinux-6-x86_64 gentoo-2-x86_64].include?(os)
             it { is_expected.not_to compile }
           else
-            it { is_expected.to contain_systemd__dropin_file('user.conf').with_content("[Service]\nUser=puppet\n") }
+            it do
+              is_expected.to contain_systemd__dropin_file('webhook-go.service-override').with(
+                filename: 'override.conf',
+                content: "[Service]\nUser=puppet\n",
+              )
+            end
+          end
+        end
+
+        context 'with github_token_path' do
+          let :params do
+            super().merge(
+              github_token_path: '/etc/voxpupuli/github.token',
+              service_user: 'webhook',
+            )
+          end
+
+          if %w[archlinux-rolling-x86_64 archlinux-6-x86_64 gentoo-2-x86_64].include?(os)
+            it { is_expected.not_to compile }
+          else
+            it { is_expected.to compile.with_all_deps }
+
+            it do
+              is_expected.to contain_file('/etc/voxpupuli').with(
+                ensure: 'directory',
+                owner: 'root',
+                group: 'root',
+                mode: '0755',
+              )
+            end
+
+            it do
+              is_expected.to contain_file('/etc/voxpupuli/r10k.gitconfig').with(
+                ensure: 'file',
+                owner: 'root',
+                group: 'webhook',
+                mode: '0440',
+                content: "[credential \"https://github.com\"]\n  helper = /etc/voxpupuli/r10k-git-credential-helper\n",
+                require: [
+                  'File[/etc/voxpupuli]',
+                  'File[/etc/voxpupuli/r10k-git-credential-helper]',
+                ],
+              )
+            end
+
+            it do
+              is_expected.to contain_file('/etc/voxpupuli/r10k-git-credential-helper').with(
+                ensure: 'file',
+                owner: 'root',
+                group: 'webhook',
+                mode: '0550',
+              ).with_content(<<~'SCRIPT')
+                #!/bin/sh
+
+                if [ "$1" = 'get' ]; then
+                  if [ ! -f /etc/voxpupuli/github.token ]; then
+                    printf '%s: %s\n' 'r10k credential helper: token file does not exist or is not a regular file' /etc/voxpupuli/github.token >&2
+                    printf 'quit=true\n\n'
+                    exit 1
+                  elif [ ! -r /etc/voxpupuli/github.token ]; then
+                    printf '%s: %s\n' 'r10k credential helper: token file is not readable' /etc/voxpupuli/github.token >&2
+                    printf 'quit=true\n\n'
+                    exit 1
+                  fi
+
+                  printf '%s\n' 'username=x-access-token'
+                  printf 'password='
+                  cat -- /etc/voxpupuli/github.token
+                  printf '\n'
+                fi
+              SCRIPT
+            end
+
+            it do
+              is_expected.to contain_systemd__dropin_file('webhook-go.service-override').with(
+                unit: 'webhook-go.service',
+                filename: 'override.conf',
+                content: <<~DROPIN,
+                  [Service]
+                  User=webhook
+                  Environment=GIT_CONFIG_GLOBAL=/etc/voxpupuli/r10k.gitconfig
+                  Environment=GIT_TERMINAL_PROMPT=0
+                DROPIN
+                require: 'Class[R10k::Webhook::Config]',
+                notify: 'Service[webhook-go.service]',
+              )
+            end
           end
         end
       end

--- a/templates/r10k-git-credential-helper.epp
+++ b/templates/r10k-git-credential-helper.epp
@@ -1,0 +1,19 @@
+<%- | String[1] $token_path | -%>
+#!/bin/sh
+
+if [ "$1" = 'get' ]; then
+  if [ ! -f <%= $token_path %> ]; then
+    printf '%s: %s\n' 'r10k credential helper: token file does not exist or is not a regular file' <%= $token_path %> >&2
+    printf 'quit=true\n\n'
+    exit 1
+  elif [ ! -r <%= $token_path %> ]; then
+    printf '%s: %s\n' 'r10k credential helper: token file is not readable' <%= $token_path %> >&2
+    printf 'quit=true\n\n'
+    exit 1
+  fi
+
+  printf '%s\n' 'username=x-access-token'
+  printf 'password='
+  cat -- <%= $token_path %>
+  printf '\n'
+fi

--- a/templates/webhook-service-override.epp
+++ b/templates/webhook-service-override.epp
@@ -1,0 +1,12 @@
+<%- |
+  Optional $service_user,
+  Optional[Stdlib::Absolutepath] $github_token_path,
+| -%>
+[Service]
+<% if $service_user { -%>
+User=<%= $service_user %>
+<% } -%>
+<% if $github_token_path { -%>
+Environment=GIT_CONFIG_GLOBAL=/etc/voxpupuli/r10k.gitconfig
+Environment=GIT_TERMINAL_PROMPT=0
+<% } -%>


### PR DESCRIPTION
#### Pull Request (PR) description

If given a token path,
* Create a git credential helper to read the token
   The helper will emit stderr message and return quit=true on missing/non-regular or unreadable token files
* Configure the webhook service to utilize the git credential helper

#### This Pull Request (PR) fixes the following issues

Makes it possible to use with CD deployments with single-use git credentials.

Signed-off-by: Jo Rhett https://github.com/jorhett
Co-authored-by: OpenAI Codex <noreply@openai.com>